### PR TITLE
Bridge 1667 active task permissions

### DIFF
--- a/ResearchUXFactory/Base.lproj/ResearchUXFactory.strings
+++ b/ResearchUXFactory/Base.lproj/ResearchUXFactory.strings
@@ -93,6 +93,7 @@
 
 /* Permissions */
 "SBA_PERMISSIONS_TITLE" = "Permissions"; // Title for the screen showing the required permissions
+"PERMISSIONS_TASK_TEXT" = "These permissions are required to perform this task. You cannot continue with this task if they are not allowed."; // Message for a permissions step added to an active task that requires permissions
 "SBA_PERMISSIONS_FAILED_TITLE" = "Not Authorized"; // Title for a popup explaining that not all required permissions have been authorized.
 "SBA_PERMISSIONS_FAILED_MESSAGE" = "Go to Settings to change your permissions."; // General purpose message for a popup explaining that not all required permissions have been authorized.
 "SBA_HEALTHKIT_PERMISSIONS_TITLE" = "Health Kit";

--- a/ResearchUXFactory/SBAActiveTask+Dictionary.swift
+++ b/ResearchUXFactory/SBAActiveTask+Dictionary.swift
@@ -60,6 +60,10 @@ extension NSDictionary: SBAActiveTask {
         guard let steps = self["localizedSteps"] as? [AnyObject] else { return nil }
         return steps.map({ return ($0 as? SBASurveyItem) ?? NSDictionary() })
     }
+    
+    public var ignorePermissions: Bool {
+        return self["ignorePermissions"] as? Bool ?? false
+    }
 
 }
 

--- a/ResearchUXFactory/SBAActiveTask.swift
+++ b/ResearchUXFactory/SBAActiveTask.swift
@@ -138,6 +138,7 @@ public protocol SBAActiveTask: SBABridgeTask, SBAStepTransformer {
     var predefinedExclusions: ORKPredefinedTaskOption? { get }
     var localizedSteps: [SBASurveyItem]? { get }
     var optional: Bool { get }
+    var ignorePermissions: Bool { get }
 }
 
 extension SBAActiveTask {
@@ -181,7 +182,7 @@ extension SBAActiveTask {
         }
         
         // Add the permissions step
-        if let permissions = permissionTypes {
+        if !self.ignorePermissions, let permissions = permissionTypes {
             task = taskWithPermissions(task, permissions)
         }
         
@@ -198,6 +199,7 @@ extension SBAActiveTask {
         
         // Add the permission step
         let permissionsStep = SBAPermissionsStep(identifier: "SBAPermissionsStep")
+        permissionsStep.text = Localization.localizedString("PERMISSIONS_TASK_TEXT")
         permissionsStep.permissionTypes = permissions
         permissionsStep.isOptional = false
         var steps = task.steps

--- a/ResearchUXFactory/SBAPermissionsManager.swift
+++ b/ResearchUXFactory/SBAPermissionsManager.swift
@@ -40,6 +40,20 @@ extension SBAPermissionsManager {
     }
     
     /**
+     Are all the permissions granted?
+     @param permissionTypes     Permissions to check
+     @return                    Whether or not all have been granted
+    */
+    public func allPermissionsAuthorized(for permissionTypes:[SBAPermissionObjectType]) -> Bool {
+        for permissionType in permissionTypes {
+            if !self.isPermissionGranted(for: permissionType) {
+                return false
+            }
+        }
+        return true
+    }
+    
+    /**
      Request permission for each permission in the list.
      
      @param     permissions     List of the permissions being requested

--- a/ResearchUXFactory/SBAPermissionsStep.swift
+++ b/ResearchUXFactory/SBAPermissionsStep.swift
@@ -33,6 +33,49 @@
 
 import ResearchKit
 
+open class SBAPermissionsSkipRule: ORKSkipStepNavigationRule {
+    
+    /**
+     Manager for handling requesting permissions
+     */
+    open var permissionsManager: SBAPermissionsManager {
+        return SBAPermissionsManager.shared
+    }
+    
+    /**
+     Permission types to request for this step of the task.
+     */
+    public let permissionTypes: [SBAPermissionObjectType]
+    
+    /**
+     Whether or not the rule should be applied
+     @param taskResult  Ignored.
+     @return            `YES` if all permissions are granted
+    */
+    open override func stepShouldSkip(with taskResult: ORKTaskResult) -> Bool {
+        return self.permissionsManager.allPermissionsAuthorized(for: self.permissionTypes)
+    }
+    
+    public required init(permissionTypes: [SBAPermissionObjectType]) {
+        self.permissionTypes = permissionTypes
+        super.init()
+    }
+    
+    public required init(coder aDecoder: NSCoder) {
+        self.permissionTypes = aDecoder.decodeObject(forKey: "permissionTypes") as! [SBAPermissionObjectType]
+        super.init(coder: aDecoder)
+    }
+    
+    open override func encode(with aCoder: NSCoder) {
+        aCoder.encode(self.permissionTypes, forKey: "permissionTypes")
+        super.encode(with: aCoder)
+    }
+    
+    override open func copy(with zone: NSZone? = nil) -> Any {
+        return type(of: self).init(permissionTypes: self.permissionTypes)
+    }
+}
+
 open class SBAPermissionsStep: ORKTableStep, SBANavigationSkipRule {
 
     /**
@@ -107,19 +150,10 @@ open class SBAPermissionsStep: ORKTableStep, SBANavigationSkipRule {
         return SBAPermissionsStepViewController.classForCoder()
     }
     
-    open func allPermissionsAuthorized() -> Bool {
-        for permissionType in permissionTypes {
-            if !self.permissionsManager.isPermissionGranted(for: permissionType) {
-                return false
-            }
-        }
-        return true
-    }
-    
     // MARK: SBANavigationSkipRule
     
     open func shouldSkipStep(with result: ORKTaskResult, and additionalTaskResults: [ORKTaskResult]?) -> Bool {
-        return allPermissionsAuthorized()
+        return self.permissionsManager.allPermissionsAuthorized(for: self.permissionTypes)
     }
     
     // MARK: Cell overrides

--- a/ResearchUXFactoryTests/ActiveTaskTests.swift
+++ b/ResearchUXFactoryTests/ActiveTaskTests.swift
@@ -76,11 +76,11 @@ class SBAActiveTaskTests: XCTestCase {
             return
         }
         
-        let expectedCount = 4
+        let expectedCount = 5
         XCTAssertEqual(task.steps.count, expectedCount, "\(task.steps)")
         guard task.steps.count == expectedCount else { return }
 
-        // Step 1 - Overview
+        // Step - Overview
         guard let instructionStep = task.steps.first as? ORKInstructionStep else {
             XCTAssert(false, "\(task.steps.first) not of expect class")
             return
@@ -88,22 +88,28 @@ class SBAActiveTaskTests: XCTestCase {
         XCTAssertEqual(instructionStep.identifier, "instruction")
         XCTAssertEqual(instructionStep.text, "intended Use Description Text")
         
-        // Step 2 - Right Hand Tapping Instruction
-        guard let rightInstructionStep = task.steps[1] as? ORKInstructionStep else {
+        // Step - Permissions Step
+        guard let _ = task.steps[1] as? SBAPermissionsStep else {
             XCTAssert(false, "\(task.steps[1]) not of expect class")
+            return
+        }
+        
+        // Step - Right Hand Tapping Instruction
+        guard let rightInstructionStep = task.steps[2] as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps[2]) not of expect class")
             return
         }
         XCTAssertEqual(rightInstructionStep.identifier, "instruction1.right")
         
-        // Step 3 - Right Hand Tapping
-        guard let rightTappingStep = task.steps[2] as? ORKTappingIntervalStep else {
-            XCTAssert(false, "\(task.steps[2]) not of expect class")
+        // Step - Right Hand Tapping
+        guard let rightTappingStep = task.steps[3] as? ORKTappingIntervalStep else {
+            XCTAssert(false, "\(task.steps[3]) not of expect class")
             return
         }
         XCTAssertEqual(rightTappingStep.identifier, "tapping.right")
         XCTAssertEqual(rightTappingStep.stepDuration, 12.0)
         
-        // Step 4 - Completion
+        // Step - Completion
         guard let completionStep = task.steps.last as? ORKCompletionStep else {
             XCTAssert(false, "\(task.steps.last) not of expect class")
             return
@@ -279,7 +285,7 @@ class SBAActiveTaskTests: XCTestCase {
             return
         }
         
-        let expectedCount = 6
+        let expectedCount = 7
         XCTAssertEqual(task.steps.count, expectedCount, "\(task.steps)")
         guard task.steps.count == expectedCount else { return }
         
@@ -291,17 +297,23 @@ class SBAActiveTaskTests: XCTestCase {
         XCTAssertEqual(instructionStep.identifier, "instruction")
         XCTAssertEqual(instructionStep.text, "intended Use Description Text")
         
-        // Step 2 - Detail Instruction
-        guard let instructionDetailStep = task.steps[1] as? ORKInstructionStep else {
+        // Step - Permissions Step
+        guard let _ = task.steps[1] as? SBAPermissionsStep else {
             XCTAssert(false, "\(task.steps[1]) not of expect class")
+            return
+        }
+        
+        // Step 2 - Detail Instruction
+        guard let instructionDetailStep = task.steps[2] as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps[2]) not of expect class")
             return
         }
         XCTAssertEqual(instructionDetailStep.identifier, "instruction1")
         XCTAssertEqual(instructionDetailStep.text, "Speech Instruction")
         
         // Step 3 - Count down
-        guard let countStep = task.steps[2] as? ORKCountdownStep else {
-            XCTAssert(false, "\(task.steps[2]) not of expect class")
+        guard let countStep = task.steps[3] as? ORKCountdownStep else {
+            XCTAssert(false, "\(task.steps[3]) not of expect class")
             return
         }
         XCTAssertEqual(countStep.identifier, "countdown")
@@ -309,8 +321,8 @@ class SBAActiveTaskTests: XCTestCase {
         XCTAssertNotNil(audioRule)
         
         // Step 4 - audio too loud
-        guard let tooLoudStep = task.steps[3] as? ORKInstructionStep else {
-            XCTAssert(false, "\(task.steps[3]) not of expect class")
+        guard let tooLoudStep = task.steps[4] as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps[4]) not of expect class")
             return
         }
         XCTAssertEqual(tooLoudStep.identifier, "audio.tooloud")
@@ -322,8 +334,8 @@ class SBAActiveTaskTests: XCTestCase {
         }
         
         // Step 5 - Audio
-        guard let audioStep = task.steps[4] as? ORKAudioStep else {
-            XCTAssert(false, "\(task.steps[4]) not of expect class")
+        guard let audioStep = task.steps[5] as? ORKAudioStep else {
+            XCTAssert(false, "\(task.steps[5]) not of expect class")
             return
         }
         XCTAssertEqual(audioStep.identifier, "audio")
@@ -359,7 +371,7 @@ class SBAActiveTaskTests: XCTestCase {
             return
         }
         
-        let expectedCount = 6
+        let expectedCount = 7
         XCTAssertEqual(task.steps.count, expectedCount, "\(task.steps)")
         guard task.steps.count == expectedCount else { return }
         
@@ -371,31 +383,37 @@ class SBAActiveTaskTests: XCTestCase {
         XCTAssertEqual(instructionStep.identifier, "instruction")
         XCTAssertEqual(instructionStep.text, "intended Use Description Text")
         
-        // Step 2 - Detail Instruction
-        guard let instructionDetailStep = task.steps[1] as? ORKInstructionStep else {
+        // Step - Permissions Step
+        guard let _ = task.steps[1] as? SBAPermissionsStep else {
             XCTAssert(false, "\(task.steps[1]) not of expect class")
+            return
+        }
+        
+        // Step 2 - Detail Instruction
+        guard let instructionDetailStep = task.steps[2] as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps[2]) not of expect class")
             return
         }
         XCTAssertEqual(instructionDetailStep.identifier, "instruction1")
         
         // Step 3 - Count down
-        guard let countStep = task.steps[2] as? ORKCountdownStep else {
-            XCTAssert(false, "\(task.steps[2]) not of expect class")
+        guard let countStep = task.steps[3] as? ORKCountdownStep else {
+            XCTAssert(false, "\(task.steps[3]) not of expect class")
             return
         }
         XCTAssertEqual(countStep.identifier, "countdown")
         
         // Step 4 - Walking
-        guard let walkingStep = task.steps[3] as? ORKWalkingTaskStep else {
-            XCTAssert(false, "\(task.steps[3]) not of expect class")
+        guard let walkingStep = task.steps[4] as? ORKWalkingTaskStep else {
+            XCTAssert(false, "\(task.steps[4]) not of expect class")
             return
         }
         XCTAssertEqual(walkingStep.identifier, "walking.outbound")
         XCTAssertEqual(walkingStep.stepDuration, 45.0)
         
         // Step 5 - Rest
-        guard let restStep = task.steps[4] as? ORKFitnessStep else {
-            XCTAssert(false, "\(task.steps[4]) not of expect class")
+        guard let restStep = task.steps[5] as? ORKFitnessStep else {
+            XCTAssert(false, "\(task.steps[5]) not of expect class")
             return
         }
         XCTAssertEqual(restStep.identifier, "walking.rest")
@@ -431,7 +449,7 @@ class SBAActiveTaskTests: XCTestCase {
             return
         }
         
-        let expectedCount = 18
+        let expectedCount = 19
         XCTAssertEqual(task.steps.count, expectedCount, "\(task.steps)")
         guard task.steps.count == expectedCount else { return }
         
@@ -443,30 +461,36 @@ class SBAActiveTaskTests: XCTestCase {
         XCTAssertEqual(instructionStep.identifier, "instruction")
         XCTAssertEqual(instructionStep.text, "intended Use Description Text")
         
-        // Step 2 - Additional Instruction
-        guard let additionalInstructionStep = task.steps[1] as? ORKInstructionStep else {
+        // Step - Permissions Step
+        guard let _ = task.steps[1] as? SBAPermissionsStep else {
             XCTAssert(false, "\(task.steps[1]) not of expect class")
+            return
+        }
+        
+        // Step 2 - Additional Instruction
+        guard let additionalInstructionStep = task.steps[2] as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps[2]) not of expect class")
             return
         }
         XCTAssertEqual(additionalInstructionStep.identifier, "instruction1.right")
         
         // Step 3 - Right Hand Tremor Instruction
-        guard let rightInstructionStep = task.steps[2] as? ORKInstructionStep else {
-            XCTAssert(false, "\(task.steps[2]) not of expect class")
+        guard let rightInstructionStep = task.steps[3] as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps[3]) not of expect class")
             return
         }
         XCTAssertEqual(rightInstructionStep.identifier, "instruction2.right")
         
         // Step 4 - Count down
-        guard let countStep = task.steps[3] as? ORKCountdownStep else {
-            XCTAssert(false, "\(task.steps[3]) not of expect class")
+        guard let countStep = task.steps[4] as? ORKCountdownStep else {
+            XCTAssert(false, "\(task.steps[4]) not of expect class")
             return
         }
         XCTAssertEqual(countStep.identifier, "countdown1.right")
         
         // Step 5 - Hand In Lap
-        guard let handInLapStep = task.steps[4] as? ORKActiveStep else {
-            XCTAssert(false, "\(task.steps[4]) not of expect class")
+        guard let handInLapStep = task.steps[5] as? ORKActiveStep else {
+            XCTAssert(false, "\(task.steps[5]) not of expect class")
             return
         }
         XCTAssertEqual(handInLapStep.identifier, "tremor.handInLap.right")
@@ -503,7 +527,8 @@ class SBAActiveTaskTests: XCTestCase {
         }
         
         let introSteps = ["instruction",
-                          "skipHand"]
+                          "skipHand",
+                          "SBAPermissionStep"]
         let bothHandSteps = ["instruction1.",
                              "instruction2.",
                              "countdown1.",
@@ -528,9 +553,15 @@ class SBAActiveTaskTests: XCTestCase {
         XCTAssertEqual(introStep.identifier, introSteps[0])
         XCTAssertEqual(introStep.text, "intended Use Description Text")
         
-        // Step - Navigation
-        guard let navStep = task.steps[1] as? ORKQuestionStep else {
+        // Step - Permissions Step
+        guard let _ = task.steps[1] as? SBAPermissionsStep else {
             XCTAssert(false, "\(task.steps[1]) not of expect class")
+            return
+        }
+        
+        // Step - Navigation
+        guard let navStep = task.steps[2] as? ORKQuestionStep else {
+            XCTAssert(false, "\(task.steps[2]) not of expect class")
             return
         }
         XCTAssertEqual(navStep.identifier, introSteps[1])

--- a/ResearchUXFactoryTests/ActiveTaskTests.swift
+++ b/ResearchUXFactoryTests/ActiveTaskTests.swift
@@ -203,6 +203,72 @@ class SBAActiveTaskTests: XCTestCase {
         XCTAssertEqual(completionStep.detailText, "Detail Text 123")
     }
     
+    func testGoNoGoTask() {
+        
+        let inputTask: NSDictionary = [
+            "taskIdentifier"            : "1-Go-No-Go",
+            "schemaIdentifier"          : "Go-No-Go",
+            "taskType"                  : "goNoGo",
+            "intendedUseDescription"    : "intended Use Description Text",
+            "localizedSteps"               : [[
+                "identifier" : "conclusion",
+                "title"      : "Title 123",
+                "text"       : "Text 123",
+                "detailText" : "Detail Text 123"
+                ]
+            ]
+        ]
+        
+        let result = inputTask.createORKTask()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.identifier, "Go-No-Go")
+        
+        guard let task = result as? ORKOrderedTask else {
+            XCTAssert(false, "\(result) not of expect class")
+            return
+        }
+        
+        let expectedCount = 5
+        XCTAssertEqual(task.steps.count, expectedCount, "\(task.steps)")
+        guard task.steps.count == expectedCount else { return }
+        
+        // Step 1 - Overview
+        guard let instructionStep = task.steps.first as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps.first) not of expect class")
+            return
+        }
+        XCTAssertEqual(instructionStep.identifier, "instruction")
+        XCTAssertEqual(instructionStep.text, "intended Use Description Text")
+        
+        // Step - Permissions
+        guard let _ = task.steps[1] as? SBAPermissionsStep else {
+            XCTAssert(false, "\(task.steps[1]) not of expect class")
+            return
+        }
+        
+        // Step - Instruction
+        guard let _ = task.steps[2] as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps[2]) not of expect class")
+            return
+        }
+
+        // Step - Active
+        guard let _ = task.steps[3] as? ORKActiveStep else {
+            XCTAssert(false, "\(task.steps[3]) not of expect class")
+            return
+        }
+        
+        // Step - Completion
+        guard let completionStep = task.steps.last as? ORKCompletionStep else {
+            XCTAssert(false, "\(task.steps.last) not of expect class")
+            return
+        }
+        XCTAssertEqual(completionStep.identifier, "conclusion")
+        XCTAssertEqual(completionStep.title, "Title 123")
+        XCTAssertEqual(completionStep.text, "Text 123")
+        XCTAssertEqual(completionStep.detailText, "Detail Text 123")
+    }
+    
     func testMemoryTask() {
         
         let inputTask: NSDictionary = [


### PR DESCRIPTION
Added BiAffect's go-no-go task and added a permissions step to each task that does not include one. This will block the user from doing the task if the json file isn't set up specifically to ignore the step.

We will probably want to work with Woody to improve the UX for this, but wanted to get something in there as a default implementation. 