### PR TITLE
BRIDGE-1773 Change to support either full name or given/family and current age

### DIFF
--- a/ResearchUXFactory.xcodeproj/project.pbxproj
+++ b/ResearchUXFactory.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		FF0158711DF6047600F417E1 /* AnswerFormatFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0158701DF6047600F417E1 /* AnswerFormatFinderTests.swift */; };
 		FF08C9301DEE1EBC00235711 /* UtilityExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF08C92F1DEE1EBC00235711 /* UtilityExtensionTests.swift */; };
 		FF08E0C01C9A6A120082D530 /* SBASurveyItem+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF08E0BF1C9A6A120082D530 /* SBASurveyItem+Dictionary.swift */; };
+		FF0A880E1E8ADF1D00708A69 /* SBANameDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0A880D1E8ADF1D00708A69 /* SBANameDataSource.swift */; };
+		FF0A88131E8AE35C00708A69 /* Date+CurrentAgeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0A88121E8AE35C00708A69 /* Date+CurrentAgeExtension.swift */; };
 		FF10F4DF1D244ACE005C9BB4 /* ORKCollectionResult+SBAExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = FF10F4DD1D244ACE005C9BB4 /* ORKCollectionResult+SBAExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF10F4E01D244ACE005C9BB4 /* ORKCollectionResult+SBAExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = FF10F4DE1D244ACE005C9BB4 /* ORKCollectionResult+SBAExtensions.m */; };
 		FF1DD9361E37DC210096727C /* SBASurveyItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1DD9351E37DC210096727C /* SBASurveyItemType.swift */; };
@@ -375,6 +377,8 @@
 		FF0395F21CFE283F00245DE3 /* ResearchKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ResearchKit.xcodeproj; path = ResearchKit/ResearchKit.xcodeproj; sourceTree = "<group>"; };
 		FF08C92F1DEE1EBC00235711 /* UtilityExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtilityExtensionTests.swift; sourceTree = "<group>"; };
 		FF08E0BF1C9A6A120082D530 /* SBASurveyItem+Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBASurveyItem+Dictionary.swift"; sourceTree = "<group>"; };
+		FF0A880D1E8ADF1D00708A69 /* SBANameDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBANameDataSource.swift; sourceTree = "<group>"; };
+		FF0A88121E8AE35C00708A69 /* Date+CurrentAgeExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+CurrentAgeExtension.swift"; sourceTree = "<group>"; };
 		FF10F4DD1D244ACE005C9BB4 /* ORKCollectionResult+SBAExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ORKCollectionResult+SBAExtensions.h"; sourceTree = "<group>"; };
 		FF10F4DE1D244ACE005C9BB4 /* ORKCollectionResult+SBAExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ORKCollectionResult+SBAExtensions.m"; sourceTree = "<group>"; };
 		FF1DD9351E37DC210096727C /* SBASurveyItemType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBASurveyItemType.swift; sourceTree = "<group>"; };
@@ -1016,8 +1020,10 @@
 		FF9425921E28593600FD8C24 /* Account */ = {
 			isa = PBXGroup;
 			children = (
+				FF0A88121E8AE35C00708A69 /* Date+CurrentAgeExtension.swift */,
 				FF5544A01E296CFC00A8E189 /* SBAHealthKitCharacteristicTypeAnswerFormat.swift */,
 				FF9425971E285BC900FD8C24 /* SBAExternalIDOptions.swift */,
+				FF0A880D1E8ADF1D00708A69 /* SBANameDataSource.swift */,
 				FF5544941E29611600A8E189 /* SBAPasswordOptions.swift */,
 				FF9425931E28594B00FD8C24 /* SBAProfileFormStep.swift */,
 				FF9425941E28594B00FD8C24 /* SBAProfileInfoForm.swift */,
@@ -1520,6 +1526,7 @@
 				FF9425411E2812F100FD8C24 /* SBAConsentSection.swift in Sources */,
 				FB8439191C727BEB0086E961 /* SBABaseSurveyFactory.swift in Sources */,
 				FF9425421E2812F100FD8C24 /* SBAConsentSection+Dictionary.swift in Sources */,
+				FF0A88131E8AE35C00708A69 /* Date+CurrentAgeExtension.swift in Sources */,
 				FF9312391DC93327001A9F86 /* SBAPermissionObjectType.swift in Sources */,
 				FF9E48961CF3A2F1005EE7E0 /* StaticUtilities.swift in Sources */,
 				FFDA29EF1D3FF216005CD0D0 /* SBATrackedActivityStep.swift in Sources */,
@@ -1578,6 +1585,7 @@
 				FF5E56E61D6F8469008BA2A8 /* SBACheckmarkView.swift in Sources */,
 				FF9425751E2823FA00FD8C24 /* SBAInfoManager.m in Sources */,
 				FF2729151D92050100956CFB /* SBATrackedStepSurveyItem+Dictionary.swift in Sources */,
+				FF0A880E1E8ADF1D00708A69 /* SBANameDataSource.swift in Sources */,
 				FF2729131D92045A00956CFB /* SBATextChoice+SBATrackedDataObject.swift in Sources */,
 				FF9425441E2812F100FD8C24 /* SBAConsentSharingOptions+Dictionary.swift in Sources */,
 				FF80920F1D01FD35003FF617 /* ORKAnswerFormat+KeyboardUtilities.swift in Sources */,

--- a/ResearchUXFactory/Base.lproj/ResearchUXFactory.strings
+++ b/ResearchUXFactory/Base.lproj/ResearchUXFactory.strings
@@ -78,6 +78,8 @@
 "SBA_REGISTRATION_FULLNAME_PLACEHOLDER" = "Enter full name"; // Placeholder for the full name during registration.
 
 /* Profile */
+"AGE_FORM_ITEM_TITLE" = "Current Age";
+"AGE_FORM_ITEM_PLACEHOLDER" = "What is your current age?";
 "BLOOD_TYPE_FORM_ITEM_TITLE" = "Blood Type";    // Title for a form item for entering blood type
 "BLOOD_TYPE_FORM_ITEM_PLACEHOLDER" = "Enter blood type";    // Placeholder for a form item for entering blood type
 "FITZPATRICK_SKIN_TYPE_FORM_ITEM_TITLE" = "Fitzpatrick Skin Type";    // Title for a form item for entering blood type

--- a/ResearchUXFactory/Date+CurrentAgeExtension.swift
+++ b/ResearchUXFactory/Date+CurrentAgeExtension.swift
@@ -1,0 +1,61 @@
+//
+//  Date+CurrentAgeExtension.swift
+//  ResearchUXFactory
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+extension Date {
+    
+    /**
+     Convenience method for getting the participant's age from their birthdate. This is used
+     to de-identify the participant when uploading demographic information. It can also be used
+     for consent and eligibility where there are age requirements.
+     @return    The current age of the given birthdate
+     */
+    public func currentAge() -> Int {
+        let calendar = Calendar(identifier: .gregorian)
+        return calendar.dateComponents([.year], from: self, to: Date()).year ?? 0
+    }
+    
+    /**
+     Convenience method for initializing a birthdate from the participant's age. This method assumes
+     that today is the participant's birthday which should be "close enough" for any study that uses
+     this method to establish demographics and eligibility based on current age.
+     
+     @param     currentAge  The participant's current age
+     */
+    public init(currentAge: Int) {
+        let calendar = Calendar(identifier: .gregorian)
+        let birthdate = calendar.date(byAdding: .year, value: -1 * currentAge, to: Date())
+        self.init(timeIntervalSinceNow: birthdate?.timeIntervalSinceNow ?? 0)
+    }
+}

--- a/ResearchUXFactory/SBANameDataSource.swift
+++ b/ResearchUXFactory/SBANameDataSource.swift
@@ -1,0 +1,79 @@
+//
+//  SBANameDataSource.swift
+//  ResearchUXFactory
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/**
+ The `SBANameDataSource` is used to normalize the presentation of the participant's name.
+ The design of an app could require recording profile infomation with a separate field for given/family name
+ or with a single field for the full name. This property can be used with either type of design.
+ */
+public protocol SBANameDataSource: class {
+    
+    /**
+     This can either be the full name or the given name for the user. (First name in Western cultures)
+     */
+    var name: String? { get }
+    
+    /**
+     Family name (last name in US locale)
+     */
+    var familyName: String? { get }
+}
+
+extension SBANameDataSource {
+    
+    /**
+     Only return a value for the given name if the family name is non-nil. Otherwise, the name field
+     is the full name and the given name cannot be parsed.
+     */
+    public var givenName: String? {
+        return (self.familyName != nil) ? self.name : nil;
+    }
+    
+    /**
+     Join the user's given and family name as appropriate to the current locale.
+     */
+    public var fullName: String? {
+        // If the family name is nil then it is assumed not to be used
+        guard let familyName = self.familyName, let givenName = self.name else {
+            return self.name
+        }
+        
+        var components = PersonNameComponents()
+        components.givenName = givenName
+        components.familyName = familyName
+        
+        return PersonNameComponentsFormatter.localizedString(from: components, style: .default, options: [])
+    }
+}

--- a/ResearchUXFactory/SBAResearchKitResultConverter.swift
+++ b/ResearchUXFactory/SBAResearchKitResultConverter.swift
@@ -162,5 +162,13 @@ extension SBAResearchKitResultConverter {
         return result.textAnswer
     }
     
+    /**
+     Convert an `ORKNumericQuestionResult` for a given result into a integer.
+     */
+    public func intAnswer(for identifier:String) -> Int? {
+        guard let result = self.findResult(for: identifier) as? ORKNumericQuestionResult else { return nil }
+        return result.numericAnswer?.intValue
+    }
+    
 }
 


### PR DESCRIPTION
This will allow setting up the consent flow to record either name as full name or given/family which will stay reverse-compatible to mPower but will support given/family for other projects. Additionally, added support for using the current age question during eligibility to convert to a birthdate for use during consent and registration.