### PR TITLE
Bridge 1773 onboarding profile info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode8.3
 before_install:
   - brew update
 install:

--- a/ResearchUXFactory.xcodeproj/project.pbxproj
+++ b/ResearchUXFactory.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		FFBBED991DA5C68B0010AA83 /* consent_overview_to_understanding@3x.m4v in Resources */ = {isa = PBXBuildFile; fileRef = FFBBED8F1DA5C68B0010AA83 /* consent_overview_to_understanding@3x.m4v */; };
 		FFBBED9A1DA5C68B0010AA83 /* consent_sensorData_to_dataGathering@3x.m4v in Resources */ = {isa = PBXBuildFile; fileRef = FFBBED901DA5C68B0010AA83 /* consent_sensorData_to_dataGathering@3x.m4v */; };
 		FFBBED9B1DA5C68B0010AA83 /* consent_understanding_to_activities@3x.m4v in Resources */ = {isa = PBXBuildFile; fileRef = FFBBED911DA5C68B0010AA83 /* consent_understanding_to_activities@3x.m4v */; };
+		FFBD87B91E93080700237109 /* ResearchKitResultConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBD87B81E93080700237109 /* ResearchKitResultConverterTests.swift */; };
 		FFC160A61CFE67B600C29AF7 /* ResearchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFC1609F1CFE672100C29AF7 /* ResearchKit.framework */; };
 		FFC41F4D1E025DBC0057526E /* SBAKeychainWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFC41F4B1E025DBC0057526E /* SBAKeychainWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FFC41F4E1E025DBC0057526E /* SBAKeychainWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = FFC41F4C1E025DBC0057526E /* SBAKeychainWrapper.m */; };
@@ -536,6 +537,7 @@
 		FFBBED8F1DA5C68B0010AA83 /* consent_overview_to_understanding@3x.m4v */ = {isa = PBXFileReference; lastKnownFileType = file; path = "consent_overview_to_understanding@3x.m4v"; sourceTree = "<group>"; };
 		FFBBED901DA5C68B0010AA83 /* consent_sensorData_to_dataGathering@3x.m4v */ = {isa = PBXFileReference; lastKnownFileType = file; path = "consent_sensorData_to_dataGathering@3x.m4v"; sourceTree = "<group>"; };
 		FFBBED911DA5C68B0010AA83 /* consent_understanding_to_activities@3x.m4v */ = {isa = PBXFileReference; lastKnownFileType = file; path = "consent_understanding_to_activities@3x.m4v"; sourceTree = "<group>"; };
+		FFBD87B81E93080700237109 /* ResearchKitResultConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResearchKitResultConverterTests.swift; sourceTree = "<group>"; };
 		FFC15FDB1CFE4F0D00C29AF7 /* ColorInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ColorInfo.plist; sourceTree = "<group>"; };
 		FFC41F4B1E025DBC0057526E /* SBAKeychainWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBAKeychainWrapper.h; sourceTree = "<group>"; };
 		FFC41F4C1E025DBC0057526E /* SBAKeychainWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBAKeychainWrapper.m; sourceTree = "<group>"; };
@@ -679,6 +681,7 @@
 				FF73B5721D38402E00E9D4BD /* EqualityTests.m */,
 				FBE551581C6D204B00C9E1AA /* NavigableOrderedTaskTests.m */,
 				FF5544991E2961F900A8E189 /* PermissionsTests.swift */,
+				FFBD87B81E93080700237109 /* ResearchKitResultConverterTests.swift */,
 				FF4F06E71CEF7DE5007BD273 /* SubtaskStepTests.swift */,
 				FB84391F1C7315030086E961 /* SurveyFactoryTests.swift */,
 				FB8439121C6E9C2A0086E961 /* SurveyNavigationTests.swift */,
@@ -1616,6 +1619,7 @@
 				FF73B5731D38402E00E9D4BD /* EqualityTests.m in Sources */,
 				FFBB57311CACEADF0041F120 /* ActiveTaskTests.swift in Sources */,
 				FB8439201C7315030086E961 /* SurveyFactoryTests.swift in Sources */,
+				FFBD87B91E93080700237109 /* ResearchKitResultConverterTests.swift in Sources */,
 				FFDECDFD1D077C2000434001 /* ConsentTests.swift in Sources */,
 				FB8439131C6E9C2A0086E961 /* SurveyNavigationTests.swift in Sources */,
 				FF6484151CB5E9BF0055B9E7 /* ResourceTestCase.swift in Sources */,

--- a/ResearchUXFactory/SBAProfileInfoOptions.swift
+++ b/ResearchUXFactory/SBAProfileInfoOptions.swift
@@ -560,43 +560,19 @@ extension SBAResearchKitResultConverter {
     }
     
     public var birthdate: Date? {
-        guard let result = self.findResult(for: SBAProfileInfoOption.birthdate.rawValue) as? ORKDateQuestionResult else { return nil }
-        return result.dateAnswer
+        return dateOfBirthAnswer(for: SBAProfileInfoOption.birthdate.rawValue)
     }
     
     public var bloodType: HKBloodType? {
-        guard let result = self.findResult(for: SBAProfileInfoOption.bloodType.rawValue) as? ORKChoiceQuestionResult
-            else { return nil }
-        if  let answer = (result.choiceAnswers?.first as? NSNumber)?.intValue {
-            return HKBloodType(rawValue: answer)
-        }
-        else if let answer = result.choiceAnswers?.first as? String {
-            // The ORKHealthKitCharacteristicTypeAnswerFormat uses a string rather
-            // than using the HKBloodType enum directly so you have to convert
-            let bloodType = ORKBloodTypeIdentifier(rawValue: answer)
-            return bloodType.healthKitBloodType()
-        }
-        else {
-            return nil
-        }
+        return bloodTypeAnswer(for: SBAProfileInfoOption.bloodType.rawValue)
     }
     
     public var fitzpatrickSkinType: HKFitzpatrickSkinType? {
-        guard let result = self.findResult(for: SBAProfileInfoOption.fitzpatrickSkinType.rawValue) as? ORKChoiceQuestionResult,
-            let answer = (result.choiceAnswers?.first as? NSNumber)?.intValue
-            else {
-                return nil
-        }
-        return HKFitzpatrickSkinType(rawValue: answer)
+        return fitzpatrickSkinTypeAnswer(for: SBAProfileInfoOption.fitzpatrickSkinType.rawValue)
     }
     
     public var wheelchairUse: Bool? {
-        guard let result = self.findResult(for: SBAProfileInfoOption.wheelchairUse.rawValue) as? ORKChoiceQuestionResult,
-            let answer = (result.choiceAnswers?.first as? NSNumber)?.boolValue
-            else {
-                return nil
-        }
-        return answer
+        return wheelchairUseAnswer(for: SBAProfileInfoOption.wheelchairUse.rawValue)
     }
     
     public var height: HKQuantity? {

--- a/ResearchUXFactoryTests/AccountTests.swift
+++ b/ResearchUXFactoryTests/AccountTests.swift
@@ -319,4 +319,45 @@ class SBAAccountTests: XCTestCase {
         let confirmationItem = step.formItem(for:"passwordConfirmation")
         XCTAssertNil(confirmationItem)
     }
+    
+    func testGivenFamilyNameStep() {
+        let input: NSDictionary = [
+            "identifier"    : "profile",
+            "type"          : "profile",
+            "title"         : "Profile",
+            "items"         : ["given", "family"]
+        ]
+        
+        let step = SBAProfileFormStep(inputItem: input)
+        XCTAssertEqual(step.identifier, "profile")
+        XCTAssertEqual(step.title, "Profile")
+        
+        let givenNameItem = step.formItem(for:"given")
+        let givenName = givenNameItem?.answerFormat as? ORKTextAnswerFormat
+        XCTAssertNotNil(givenNameItem)
+        XCTAssertNotNil(givenName, "\(String(describing: givenNameItem?.answerFormat))")
+        
+        let familyNameItem = step.formItem(for:"family")
+        let familyName = familyNameItem?.answerFormat as? ORKTextAnswerFormat
+        XCTAssertNotNil(familyNameItem)
+        XCTAssertNotNil(familyName, "\(String(describing: familyNameItem?.answerFormat))")
+    }
+    
+    func testCurrentAgeStep() {
+        let input: NSDictionary = [
+            "identifier"    : "profile",
+            "type"          : "profile",
+            "title"         : "Profile",
+            "items"         : ["currentAge"]
+        ]
+        
+        let step = SBAProfileFormStep(inputItem: input)
+        XCTAssertEqual(step.identifier, "profile")
+        XCTAssertEqual(step.title, "Profile")
+        
+        let currentAgeItem = step.formItem(for:"currentAge")
+        let currentAge = currentAgeItem?.answerFormat as? ORKNumericAnswerFormat
+        XCTAssertNotNil(currentAgeItem)
+        XCTAssertNotNil(currentAge, "\(String(describing: currentAgeItem?.answerFormat))")
+    }
 }

--- a/ResearchUXFactoryTests/ORKFormStep+Result.swift
+++ b/ResearchUXFactoryTests/ORKFormStep+Result.swift
@@ -215,3 +215,66 @@ extension ORKScaleAnswerFormat : SBAQuestionResultMapping {
     }
     
 }
+
+extension ORKNumericAnswerFormat : SBAQuestionResultMapping {
+    
+    func instantiateQuestionResult(_ identifier: String, _ defaultAnswer: SBADefaultFormItemAnswer, _ answer: AnyObject?) -> ORKQuestionResult? {
+        
+        let result = ORKNumericQuestionResult(identifier: identifier)
+        if let num = answer as? NSNumber {
+            result.numericAnswer = num
+        }
+        else if let str = answer as? String,
+            let num = str.components(separatedBy: CharacterSet.whitespaces).first,
+            let unit = str.components(separatedBy: CharacterSet.whitespaces).last {
+            if self.questionType == .integer {
+                result.numericAnswer = NSNumber(value: Int(num) ?? 0)
+            }
+            else {
+                result.numericAnswer = NSNumber(value: Double(num) ?? 0)
+            }
+            result.unit = unit
+        }
+        else {
+            switch defaultAnswer {
+            case .defaultValue:
+                result.numericAnswer = 0
+            case .first:
+                result.numericAnswer = self.minimum as NSNumber?
+            case .last:
+                result.numericAnswer = self.maximum as NSNumber?
+            case .skip:
+                result.numericAnswer = nil
+            }
+        }
+        
+        return result
+    }
+    
+}
+
+extension ORKHeightAnswerFormat : SBAQuestionResultMapping {
+    
+    func instantiateQuestionResult(_ identifier: String, _ defaultAnswer: SBADefaultFormItemAnswer, _ answer: AnyObject?) -> ORKQuestionResult? {
+        
+        let result = ORKNumericQuestionResult(identifier: identifier)
+        if let num = answer as? NSNumber {
+            result.numericAnswer = num
+            result.unit = HKUnit.meterUnit(with: .centi).unitString
+        }
+        
+        return result
+    }
+}
+
+extension ORKTimeOfDayAnswerFormat : SBAQuestionResultMapping {
+    
+    func instantiateQuestionResult(_ identifier: String, _ defaultAnswer: SBADefaultFormItemAnswer, _ answer: AnyObject?) -> ORKQuestionResult? {
+        
+        let result = ORKTimeOfDayQuestionResult(identifier: identifier)
+        result.dateComponentsAnswer = answer as? DateComponents
+        
+        return result
+    }
+}
+

--- a/ResearchUXFactoryTests/ResearchKitResultConverterTests.swift
+++ b/ResearchUXFactoryTests/ResearchKitResultConverterTests.swift
@@ -1,0 +1,174 @@
+//
+//  ResearchKitResultConverterTests.swift
+//  ResearchUXFactory
+//
+//  Copyright (c) 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import XCTest
+@testable import ResearchUXFactory
+import HealthKit
+
+class MockResultConverter: NSObject, SBAResearchKitResultConverter {
+    
+    var answerFormatFinder: SBAAnswerFormatFinder?
+    var results: [ORKResult] = []
+    
+    func findResult(for identifier: String) -> ORKResult? {
+        return results.find(withIdentifier: identifier)
+    }
+}
+
+class ResearchKitResultConverterTests: XCTestCase {
+    
+    func testTextAnswer() {
+        
+        let converter = MockResultConverter()
+        let resultA = ORKTextQuestionResult(identifier: "A")
+        resultA.textAnswer = "answer A"
+        let resultB = ORKTextQuestionResult(identifier: "B")
+        resultB.textAnswer = "answer B"
+        let resultC = ORKTextQuestionResult(identifier: "C")
+        let resultD = ORKNumericQuestionResult(identifier: "D")
+        resultD.numericAnswer = 5
+        
+        converter.results = [resultA, resultB, resultC, resultD]
+        XCTAssertEqual(converter.textAnswer(for: "A"), "answer A")
+        XCTAssertNil(converter.textAnswer(for: "D"))
+    }
+    
+    func textIntAnswer() {
+        let converter = MockResultConverter()
+        let resultA = ORKTextQuestionResult(identifier: "A")
+        resultA.textAnswer = "answer A"
+        let resultB = ORKTextQuestionResult(identifier: "B")
+        resultB.textAnswer = "answer B"
+        let resultC = ORKNumericQuestionResult(identifier: "C")
+        let resultD = ORKNumericQuestionResult(identifier: "D")
+        resultD.numericAnswer = 5
+        
+        converter.results = [resultA, resultB, resultC, resultD]
+        XCTAssertNil(converter.intAnswer(for: "A"))
+        XCTAssertEqual(converter.intAnswer(for: "D"), 5)
+    }
+    
+    func testTimeOfDay() {
+        let converter = MockResultConverter()
+        let resultA = ORKTextQuestionResult(identifier: "A")
+        resultA.textAnswer = "answer A"
+        let resultB = ORKTextQuestionResult(identifier: "B")
+        resultB.textAnswer = "answer B"
+        let resultC = ORKTimeOfDayQuestionResult(identifier: "C")
+        let resultD = ORKTimeOfDayQuestionResult(identifier: "D")
+        
+        var timeOfDay = DateComponents()
+        timeOfDay.hour = 6
+        timeOfDay.minute = 20
+        resultD.dateComponentsAnswer = timeOfDay
+        
+        converter.results = [resultA, resultB, resultC, resultD]
+        XCTAssertNil(converter.timeOfDay(for: "A"))
+        XCTAssertEqual(converter.timeOfDay(for: "D"), timeOfDay)
+    }
+    
+    func testProfileResults() {
+        
+        // NOTE: If this test fails, check that AccountTests.testCreateProfileFormStep() is passing
+        // b/c for convenience, I am using the same methods to create the step
+        let input: NSDictionary = [
+            "identifier"    : "profile",
+            "type"          : "profile",
+            "title"         : "Profile",
+            "items"         : ["externalID", "name", "birthdate", "gender", "bloodType", "fitzpatrickSkinType", "wheelchairUse", "height", "weight", "wakeTime", "sleepTime"]
+        ]
+        
+        let step = SBAProfileFormStep(inputItem: input)
+        
+        let converter = MockResultConverter()
+        converter.answerFormatFinder = step
+        
+        let birthdate = Date(timeIntervalSince1970: 2*12*365*24 + 3*30) // Not really important to use a calendar date
+        var wakeTime = DateComponents()
+        wakeTime.hour = 8
+        var sleepTime = DateComponents()
+        sleepTime.hour = 22
+        
+        let stepResult = step.instantiateDefaultStepResult(["externalID" : "1234ABCD",
+                                                            "name" : "Joe Smith",
+                                                            "birthdate" : birthdate,
+                                                            "gender" : ["HKBiologicalSexFemale"],
+                                                            "bloodType" : ["HKBloodTypeBNegative"],
+                                                            "wheelchairUse" : [true],
+                                                            "height" : 158,
+                                                            "weight" : "120 lb",
+                                                            "wakeTime" : wakeTime,
+                                                            "sleepTime" : sleepTime])
+        converter.results = stepResult.results!
+        
+        // -- Test that the Profile Info properties are correct
+        
+        XCTAssertEqual(converter.externalID, "1234ABCD")
+        XCTAssertEqual(converter.birthdate, birthdate)
+        XCTAssertEqual(converter.name, "Joe Smith")
+        XCTAssertEqual(converter.gender, HKBiologicalSex.female)
+        XCTAssertEqual(converter.bloodType, HKBloodType.bNegative)
+        XCTAssertEqual(converter.wheelchairUse, true)
+        XCTAssertEqual(converter.wakeTime, wakeTime)
+        XCTAssertEqual(converter.sleepTime, sleepTime)
+        
+        let expectedHeight = HKQuantity(unit: HKUnit.meterUnit(with: .centi), doubleValue: 158)
+        XCTAssertEqual(converter.height, expectedHeight)
+        
+        let expectedWeight = HKQuantity(unit: HKUnit.pound(), doubleValue: 120)
+        XCTAssertEqual(converter.weight, expectedWeight)
+        
+        // -- Check that the stored result returns the same values 
+        
+        let storedGender = converter.storedAnswer(for: "gender") as? HKBiologicalSex
+        XCTAssertEqual(storedGender, HKBiologicalSex.female)
+        
+        let storedBloodType = converter.storedAnswer(for: "bloodType") as? HKBloodType
+        XCTAssertEqual(storedBloodType, HKBloodType.bNegative)
+        
+        let storedWheelchairUse = converter.storedAnswer(for: "wheelchairUse") as? Bool
+        XCTAssertEqual(storedWheelchairUse, true)
+        
+        let storedHeight = converter.storedAnswer(for: "height") as? HKQuantity
+        XCTAssertEqual(storedHeight, expectedHeight)
+        
+        let storedWeight = converter.storedAnswer(for: "weight") as? HKQuantity
+        XCTAssertEqual(storedWeight, expectedWeight)
+        
+        let storedWakeTime = converter.storedAnswer(for: "wakeTime") as? DateComponents
+        XCTAssertEqual(storedWakeTime, wakeTime)
+        
+        let storedSleepTime = converter.storedAnswer(for: "sleepTime") as? DateComponents
+        XCTAssertEqual(storedSleepTime, sleepTime)
+    }
+}


### PR DESCRIPTION
Add method for getting the `storedAnswer` which maps to the value that is stored in the user's profile. This is different from the archived result which has to be stored in JSON format and is intended to be reverse-compatible to the storage objects that are used by mPower.