### PR TITLE
Fix navigation bug that caused ineligibile result to continue to next section

### DIFF
--- a/ResearchUXFactory/SBANavigableOrderedTask.swift
+++ b/ResearchUXFactory/SBANavigableOrderedTask.swift
@@ -170,9 +170,16 @@ open class SBANavigableOrderedTask: ORKOrderedTask, ORKTaskResultSource {
         if let subtaskStep = subtaskStep(identifier: step?.identifier) {
             returnStep = subtaskStep.stepAfterStep(step, withResult: result)
             if (returnStep == nil) {
-                // If the subtask returns nil then it is at the last step
-                // Check super for more steps
-                returnStep = superStep(after: subtaskStep, with: result)
+                // If the returned step is nil then this subtask is done
+                // Look to see if the calling step returned an identifier
+                if let navigableStep = step as? SBANavigationRule,
+                    let nextStepIdentifier = navigableStep.nextStepIdentifier(with: subtaskStep.filteredTaskResult(result), and:nil) {
+                    returnStep = self.step(withIdentifier: nextStepIdentifier)
+                }
+                else {
+                    // Check super for more steps
+                    returnStep = superStep(after: subtaskStep, with: result)
+                }
             }
         }
         else {

--- a/ResearchUXFactory/SBASubtaskStep.swift
+++ b/ResearchUXFactory/SBASubtaskStep.swift
@@ -74,7 +74,7 @@ open class SBASubtaskStep: ORKStep {
         return step.copy(withIdentifier: stepIdentifier)
     }
     
-    fileprivate func filteredTaskResult(_ inputResult: ORKTaskResult) -> ORKTaskResult {
+    func filteredTaskResult(_ inputResult: ORKTaskResult) -> ORKTaskResult {
         // create a mutated copy of the results that includes only the subtask results
         let subtaskResult: ORKTaskResult = inputResult.copy() as! ORKTaskResult
         if let stepResults = subtaskResult.results as? [ORKStepResult] {


### PR DESCRIPTION
Not sure when I introduced this bug, but apparently I didn’t have a test covering navigation when the next step identifier points at a NULL step. Oops.