### PR TITLE
Update ResearchKit pointer to Sage-Bionetworks/master

### DIFF
--- a/ResearchUXFactory/SBABaseSurveyFactory.swift
+++ b/ResearchUXFactory/SBABaseSurveyFactory.swift
@@ -421,8 +421,8 @@ extension SBAFormStepSurveyItem {
             let answerFormat = ORKTextAnswerFormat()
             answerFormat.multipleLines = (subtype == .multipleLineText)
             if let range = self.range as? SBATextFieldRange {
-                if let validationRegex = range.validationRegex {
-                    answerFormat.validationRegex = validationRegex
+                if let validationRegex = range.createRegularExpression() {
+                    answerFormat.validationRegularExpression = validationRegex
                     answerFormat.invalidMessage = {
                         guard let invalidMessage = range.invalidMessage else {
                             print("Warning: The validation Regex does not have an associated validation message.")

--- a/ResearchUXFactory/SBAProfileInfoOptions.swift
+++ b/ResearchUXFactory/SBAProfileInfoOptions.swift
@@ -318,7 +318,7 @@ public struct SBAProfileInfoOptions {
         if let options = textFieldOptions {
             answerFormat.autocapitalizationType = options.autocapitalizationType
             answerFormat.keyboardType = options.keyboardType
-            answerFormat.validationRegex = options.validationRegex
+            answerFormat.validationRegularExpression = options.createRegularExpression()
             answerFormat.invalidMessage = options.invalidMessage
             answerFormat.maximumLength = options.maximumLength
         }

--- a/ResearchUXFactory/SBASurveyItem.swift
+++ b/ResearchUXFactory/SBASurveyItem.swift
@@ -224,6 +224,15 @@ public protocol SBATextFieldRange: class {
     var keyboardType: UIKeyboardType { get }
 }
 
+extension SBATextFieldRange {
+    
+    public func createRegularExpression() -> NSRegularExpression? {
+        guard let regex = self.validationRegex else { return nil }
+        return try? NSRegularExpression(pattern: regex, options: [])
+    }
+    
+}
+
 /**
  Additional properties used when creating an `ORKDateAnswerFormat`. This protocol
  should be returned by the `SBAFormStepSurveyItem` for the `range` property.

--- a/ResearchUXFactoryTests/AccountTests.swift
+++ b/ResearchUXFactoryTests/AccountTests.swift
@@ -164,7 +164,7 @@ class SBAAccountTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(passwordFormat.validationRegex, "[[:ascii:]]{8,24}")
+        XCTAssertEqual(passwordFormat.validationRegularExpression?.pattern, "[[:ascii:]]{8,24}")
         XCTAssertEqual(passwordFormat.invalidMessage, "Passwords must be between 8 and 24 characters long.")
         XCTAssertEqual(passwordFormat.maximumLength, 24)
         XCTAssertFalse(passwordFormat.multipleLines)
@@ -223,7 +223,7 @@ class SBAAccountTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(passwordFormat.validationRegex, "[[:ascii:]]{4,16}")
+        XCTAssertEqual(passwordFormat.validationRegularExpression?.pattern, "[[:ascii:]]{4,16}")
         XCTAssertEqual(passwordFormat.invalidMessage, "Passwords must be between 4 and 16 characters long.")
         XCTAssertEqual(passwordFormat.maximumLength, 16)
         XCTAssertFalse(passwordFormat.multipleLines)
@@ -267,7 +267,7 @@ class SBAAccountTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(passwordFormat.validationRegex, "abc")
+        XCTAssertEqual(passwordFormat.validationRegularExpression?.pattern, "abc")
         XCTAssertEqual(passwordFormat.invalidMessage, "ABC 123")
         XCTAssertEqual(passwordFormat.maximumLength, 24)
         XCTAssertFalse(passwordFormat.multipleLines)
@@ -306,7 +306,7 @@ class SBAAccountTests: XCTestCase {
             return
         }
         
-        XCTAssertNil(passwordFormat.validationRegex)
+        XCTAssertNil(passwordFormat.validationRegularExpression)
         XCTAssertNil(passwordFormat.invalidMessage)
         XCTAssertEqual(passwordFormat.maximumLength, 0)
         XCTAssertFalse(passwordFormat.multipleLines)

--- a/ResearchUXFactoryTests/SurveyFactoryTests.swift
+++ b/ResearchUXFactoryTests/SurveyFactoryTests.swift
@@ -128,9 +128,12 @@ class SBABaseSurveyFactoryTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(rules[0].resultIdentifier, "question1")
-        XCTAssertEqual(rules[1].resultIdentifier, "question2")
-        XCTAssertEqual(rules[2].resultIdentifier, "question3")
+        let rule1 = rules.first(where: { $0.resultIdentifier == "question1"} )
+        XCTAssertNotNil(rule1)
+        let rule2 = rules.first(where: { $0.resultIdentifier == "question2"} )
+        XCTAssertNotNil(rule2)
+        let rule3 = rules.first(where: { $0.resultIdentifier == "question3"} )
+        XCTAssertNotNil(rule3)
         
         XCTAssertEqual(rules[0].skipIdentifier, "consent")
         XCTAssertEqual(rules[1].skipIdentifier, "consent")
@@ -217,9 +220,12 @@ class SBABaseSurveyFactoryTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(rules[0].resultIdentifier, "question1")
-        XCTAssertEqual(rules[1].resultIdentifier, "question2")
-        XCTAssertEqual(rules[2].resultIdentifier, "question3")
+        let rule1 = rules.first(where: { $0.resultIdentifier == "question1"} )
+        XCTAssertNotNil(rule1)
+        let rule2 = rules.first(where: { $0.resultIdentifier == "question2"} )
+        XCTAssertNotNil(rule2)
+        let rule3 = rules.first(where: { $0.resultIdentifier == "question3"} )
+        XCTAssertNotNil(rule3)
         
         XCTAssertEqual(rules[0].skipIdentifier, "consent")
         XCTAssertEqual(rules[1].skipIdentifier, "consent")


### PR DESCRIPTION
Note: ResearchKit/ResearchKit accepted more breaking changes by removing the validation regex string from `ORKTextAnswerFormat`. This update our protocol to conform to the new properties.

