### PR TITLE
Allow a survey to trigger early exit when combining surveys

### DIFF
--- a/ResearchUXFactory/SBASubtaskStep.swift
+++ b/ResearchUXFactory/SBASubtaskStep.swift
@@ -36,7 +36,7 @@ import ResearchKit
 /**
  * The subtask step is a logical grouping of steps where the steps are defined by a subtask.
  */
-open class SBASubtaskStep: ORKStep {
+open class SBASubtaskStep: ORKStep, SBAConditionalExit {
     
     open var taskIdentifier: String?
     open var schemaIdentifier: String?
@@ -138,6 +138,20 @@ open class SBASubtaskStep: ORKStep {
         
         // And finally return the replacement step
         return replacementStep(nextStep)
+    }
+    
+    open func shouldEndTask(step: ORKStep?, with result: ORKTaskResult) -> Bool {
+        guard let conditionalExit = self.subtask as? SBAConditionalExit,
+            let step = step,
+            let substepIdentifier = substepIdentifier(step.identifier)
+        else {
+            return false
+        }
+        
+        let substep = step.copy(withIdentifier: substepIdentifier)
+        let replacementTaskResult = filteredTaskResult(result)
+
+        return conditionalExit.shouldEndTask(step: substep, with: replacementTaskResult)
     }
     
     public func stepResult(forStepIdentifier stepIdentifier: String) -> ORKStepResult? {


### PR DESCRIPTION
I discovered an issue where an early exit from a survey will drop into the next survey (rather than ending the entire stack). Eventually, will need to look into being able to have the navigation specify *which* type of navigation is desired... maybe? Or that might just be overkill since this is already pretty complicated. ;)