### PR TITLE
Move custom Elevate UI to BridgeAppSDK (ResearchUXFactory)

### DIFF
--- a/ResearchUXFactory.xcodeproj/project.pbxproj
+++ b/ResearchUXFactory.xcodeproj/project.pbxproj
@@ -7,6 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		032D3E631F0EB07B00AB8D33 /* SBAGenericStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E621F0EB07B00AB8D33 /* SBAGenericStepViewController.swift */; };
+		032D3E681F0EB09900AB8D33 /* SBAGenericPageStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E671F0EB09900AB8D33 /* SBAGenericPageStepViewController.swift */; };
+		032D3E6A1F0EB1DE00AB8D33 /* SBAStepNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E691F0EB1DE00AB8D33 /* SBAStepNavigationView.swift */; };
+		032D3E6C1F0EB24000AB8D33 /* SBAStepHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E6B1F0EB24000AB8D33 /* SBAStepHeaderView.swift */; };
+		032D3E6E1F0EB29700AB8D33 /* SBAStepProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E6D1F0EB29700AB8D33 /* SBAStepProgressView.swift */; };
+		032D3E701F0EB2EC00AB8D33 /* SBAStepChoiceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E6F1F0EB2EC00AB8D33 /* SBAStepChoiceTableViewCell.swift */; };
+		032D3E731F0EB3C200AB8D33 /* SBAGenericStepDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E721F0EB3C200AB8D33 /* SBAGenericStepDataSource.swift */; };
+		032D3E851F0EBED000AB8D33 /* SBARoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E841F0EBED000AB8D33 /* SBARoundedButton.swift */; };
+		032D3E891F0ED72700AB8D33 /* SBAShadowGradient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E881F0ED72700AB8D33 /* SBAShadowGradient.swift */; };
+		032D3E8B1F0EE07400AB8D33 /* SBAUnderlinedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E8A1F0EE07400AB8D33 /* SBAUnderlinedButton.swift */; };
+		032D3E8E1F0EE35600AB8D33 /* UIColor+BridgeKeyNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E8D1F0EE35600AB8D33 /* UIColor+BridgeKeyNames.swift */; };
+		032D3E911F0EE58700AB8D33 /* UIFont+BridgeKeyNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E901F0EE58700AB8D33 /* UIFont+BridgeKeyNames.swift */; };
+		032D3E991F0EEC3C00AB8D33 /* NSLayoutConstraint+setMultiplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E981F0EEC3C00AB8D33 /* NSLayoutConstraint+setMultiplier.swift */; };
+		032D3E9B1F0F0FD400AB8D33 /* SBAVisualConsentStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E9A1F0F0FD400AB8D33 /* SBAVisualConsentStep.swift */; };
+		032D3E9D1F0FF4CC00AB8D33 /* SBAFormStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032D3E9C1F0FF4CC00AB8D33 /* SBAFormStep.swift */; };
 		801040B51C5A843D00D26E19 /* ResearchUXFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 801040B41C5A843D00D26E19 /* ResearchUXFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		801040BC1C5A843D00D26E19 /* ResearchUXFactory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 801040B21C5A843D00D26E19 /* ResearchUXFactory.framework */; };
 		804B30AF1CEA6CB4008CEA89 /* SBAJSONObject.m in Sources */ = {isa = PBXBuildFile; fileRef = FF6410FE1CB2DC21007FB9E1 /* SBAJSONObject.m */; };
@@ -341,6 +356,21 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		032D3E621F0EB07B00AB8D33 /* SBAGenericStepViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAGenericStepViewController.swift; sourceTree = "<group>"; };
+		032D3E671F0EB09900AB8D33 /* SBAGenericPageStepViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAGenericPageStepViewController.swift; sourceTree = "<group>"; };
+		032D3E691F0EB1DE00AB8D33 /* SBAStepNavigationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAStepNavigationView.swift; sourceTree = "<group>"; };
+		032D3E6B1F0EB24000AB8D33 /* SBAStepHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAStepHeaderView.swift; sourceTree = "<group>"; };
+		032D3E6D1F0EB29700AB8D33 /* SBAStepProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAStepProgressView.swift; sourceTree = "<group>"; };
+		032D3E6F1F0EB2EC00AB8D33 /* SBAStepChoiceTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAStepChoiceTableViewCell.swift; sourceTree = "<group>"; };
+		032D3E721F0EB3C200AB8D33 /* SBAGenericStepDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAGenericStepDataSource.swift; sourceTree = "<group>"; };
+		032D3E841F0EBED000AB8D33 /* SBARoundedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBARoundedButton.swift; sourceTree = "<group>"; };
+		032D3E881F0ED72700AB8D33 /* SBAShadowGradient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAShadowGradient.swift; sourceTree = "<group>"; };
+		032D3E8A1F0EE07400AB8D33 /* SBAUnderlinedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAUnderlinedButton.swift; sourceTree = "<group>"; };
+		032D3E8D1F0EE35600AB8D33 /* UIColor+BridgeKeyNames.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+BridgeKeyNames.swift"; sourceTree = "<group>"; };
+		032D3E901F0EE58700AB8D33 /* UIFont+BridgeKeyNames.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+BridgeKeyNames.swift"; sourceTree = "<group>"; };
+		032D3E981F0EEC3C00AB8D33 /* NSLayoutConstraint+setMultiplier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+setMultiplier.swift"; sourceTree = "<group>"; };
+		032D3E9A1F0F0FD400AB8D33 /* SBAVisualConsentStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAVisualConsentStep.swift; sourceTree = "<group>"; };
+		032D3E9C1F0FF4CC00AB8D33 /* SBAFormStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAFormStep.swift; sourceTree = "<group>"; };
 		161479CF1BD6CE8F0099A068 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		801040B21C5A843D00D26E19 /* ResearchUXFactory.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ResearchUXFactory.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		801040B41C5A843D00D26E19 /* ResearchUXFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ResearchUXFactory.h; sourceTree = "<group>"; };
@@ -592,6 +622,30 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		032D3E711F0EB37B00AB8D33 /* DataSource */ = {
+			isa = PBXGroup;
+			children = (
+				032D3E721F0EB3C200AB8D33 /* SBAGenericStepDataSource.swift */,
+			);
+			name = DataSource;
+			sourceTree = "<group>";
+		};
+		032D3E8C1F0EE32200AB8D33 /* Color Management */ = {
+			isa = PBXGroup;
+			children = (
+				032D3E8D1F0EE35600AB8D33 /* UIColor+BridgeKeyNames.swift */,
+			);
+			name = "Color Management";
+			sourceTree = "<group>";
+		};
+		032D3E8F1F0EE55F00AB8D33 /* Font Management */ = {
+			isa = PBXGroup;
+			children = (
+				032D3E901F0EE58700AB8D33 /* UIFont+BridgeKeyNames.swift */,
+			);
+			name = "Font Management";
+			sourceTree = "<group>";
+		};
 		161479B71BD6CE8F0099A068 = {
 			isa = PBXGroup;
 			children = (
@@ -759,6 +813,7 @@
 				FF6410F91CAF39B4007FB9E1 /* String+Utilities.swift */,
 				FF9E48951CF3A2F1005EE7E0 /* StaticUtilities.swift */,
 				FBF1B6B21CAAF6FC007C1082 /* UIAlertController+Utilities.swift */,
+				032D3E981F0EEC3C00AB8D33 /* NSLayoutConstraint+setMultiplier.swift */,
 				FFC41F331E025DA50057526E /* Keychain */,
 				FBAE3CF01C861587003CEC4A /* PDF */,
 			);
@@ -834,6 +889,8 @@
 				FF30756F1DF7384F00F2B3EA /* SBAStepViewControllerProtocol.swift */,
 				FB6BA0961C7CDB2600C9903F /* SBASubtaskStep.swift */,
 				FF36DC6E1DB68F230034C85D /* SBAToggleFormStep.swift */,
+				032D3E9A1F0F0FD400AB8D33 /* SBAVisualConsentStep.swift */,
+				032D3E9C1F0FF4CC00AB8D33 /* SBAFormStep.swift */,
 			);
 			name = Step;
 			sourceTree = "<group>";
@@ -932,6 +989,8 @@
 			isa = PBXGroup;
 			children = (
 				FF63D0C91CCFF517007ADEE5 /* SBAWebViewController.swift */,
+				032D3E621F0EB07B00AB8D33 /* SBAGenericStepViewController.swift */,
+				032D3E671F0EB09900AB8D33 /* SBAGenericPageStepViewController.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -1037,9 +1096,12 @@
 		FFA8E4AD1CBD7CB700ED5399 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				032D3E8F1F0EE55F00AB8D33 /* Font Management */,
+				032D3E8C1F0EE32200AB8D33 /* Color Management */,
 				FFAAF63A1CC0A85900500929 /* Protocols */,
 				FFAAF63B1CC0A86800500929 /* Views */,
 				FF63D0BF1CCFF3E7007ADEE5 /* ViewControllers */,
+				032D3E711F0EB37B00AB8D33 /* DataSource */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -1067,6 +1129,9 @@
 		FFAAF63B1CC0A86800500929 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				032D3E881F0ED72700AB8D33 /* SBAShadowGradient.swift */,
+				032D3E841F0EBED000AB8D33 /* SBARoundedButton.swift */,
+				032D3E8A1F0EE07400AB8D33 /* SBAUnderlinedButton.swift */,
 				FFAAF6381CC0A42A00500929 /* SBABorderedButton.swift */,
 				FF5E56E51D6F8469008BA2A8 /* SBACheckmarkView.swift */,
 				FFCF37DF1CDA99120090452F /* UIView+LayoutExtensions.swift */,
@@ -1074,6 +1139,10 @@
 				FF77F4711D4AC5E10005503E /* SBAMultipleLineTableViewCell.swift */,
 				FF36DCBC1DB6CE840034C85D /* SBAToggleTableViewCell.swift */,
 				FF36DCBD1DB6CE840034C85D /* SBAToggleTableViewCell.xib */,
+				032D3E691F0EB1DE00AB8D33 /* SBAStepNavigationView.swift */,
+				032D3E6B1F0EB24000AB8D33 /* SBAStepHeaderView.swift */,
+				032D3E6D1F0EB29700AB8D33 /* SBAStepProgressView.swift */,
+				032D3E6F1F0EB2EC00AB8D33 /* SBAStepChoiceTableViewCell.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1507,16 +1576,19 @@
 				FF94256D1E281BC000FD8C24 /* SBAResearchKitResultConverter.swift in Sources */,
 				FBAD11671CADCFE5005611D0 /* SBATrackedDataObjectCollection.swift in Sources */,
 				FF9425431E2812F100FD8C24 /* SBAConsentSharingOptions.swift in Sources */,
+				032D3E911F0EE58700AB8D33 /* UIFont+BridgeKeyNames.swift in Sources */,
 				804B30AF1CEA6CB4008CEA89 /* SBAJSONObject.m in Sources */,
 				FF052EBC1ECF7A1A000835DB /* SBATextFieldOptions.swift in Sources */,
 				FF64113A1CB436B6007FB9E1 /* SBAClassTypeMap.m in Sources */,
 				FFB30D691D4139B400D175D2 /* SBATrackedSelectionStep.swift in Sources */,
 				FBC45E7A1C759040007AA424 /* Localization.swift in Sources */,
 				FF2729171D92057600956CFB /* SBATrackedActivitySurveyItem+Dictionary.swift in Sources */,
+				032D3E9B1F0F0FD400AB8D33 /* SBAVisualConsentStep.swift in Sources */,
 				FF9425A01E28606300FD8C24 /* NSDate+ISO8601Format.m in Sources */,
 				FFE57F221E393E3D00CEC67F /* SBANavigationFormStep.swift in Sources */,
 				FBAE3CF41C8615DF003CEC4A /* SBAPDFPrintPageRenderer.m in Sources */,
 				FF27290D1D92036A00956CFB /* SBAPopUpLearnMoreAction.swift in Sources */,
+				032D3E631F0EB07B00AB8D33 /* SBAGenericStepViewController.swift in Sources */,
 				FB84392D1C7518FE0086E961 /* SBAChoice.swift in Sources */,
 				FF55449F1E296C6A00A8E189 /* SBAProfileInfoOptions.swift in Sources */,
 				FF36DC6F1DB68F230034C85D /* SBAToggleFormStep.swift in Sources */,
@@ -1548,6 +1620,7 @@
 				FBAD115A1CADB2F0005611D0 /* SBADataObject.m in Sources */,
 				FF36DCBE1DB6CE840034C85D /* SBAToggleTableViewCell.swift in Sources */,
 				FFA8E4AA1CBD6E0B00ED5399 /* NSError+SBBTranslation.swift in Sources */,
+				032D3E991F0EEC3C00AB8D33 /* NSLayoutConstraint+setMultiplier.swift in Sources */,
 				FF35B8EC1D9DA93C00E0DF23 /* SBADataGroupsStep.swift in Sources */,
 				FF2728881D91CFB900956CFB /* SBAClassTypeMap.swift in Sources */,
 				FF8359231D6FACED0028B899 /* SBADirectNavigationRule.swift in Sources */,
@@ -1564,6 +1637,7 @@
 				FF5E56E81D6F8941008BA2A8 /* SBATaskViewController.swift in Sources */,
 				FFB30E3A1D488F4800D175D2 /* SBALoadingView.swift in Sources */,
 				FFCF385D1CE1172A0090452F /* NSPredicate+Utilities.swift in Sources */,
+				032D3E681F0EB09900AB8D33 /* SBAGenericPageStepViewController.swift in Sources */,
 				FFCF37B31CD94EC80090452F /* ORKOrderedTask+SBAExtension.m in Sources */,
 				FF27290F1D9203AD00956CFB /* SBASkipAction.swift in Sources */,
 				FF3075701DF7384F00F2B3EA /* SBAStepViewControllerProtocol.swift in Sources */,
@@ -1571,30 +1645,40 @@
 				FBE551691C6D9CBC00C9E1AA /* SBASurveyNavigationStep.swift in Sources */,
 				FF9425711E2821FC00FD8C24 /* SBAInfoManager.swift in Sources */,
 				FF641F291D945596001EE1BD /* SBATrackedDataStore.swift in Sources */,
+				032D3E6C1F0EB24000AB8D33 /* SBAStepHeaderView.swift in Sources */,
+				032D3E701F0EB2EC00AB8D33 /* SBAStepChoiceTableViewCell.swift in Sources */,
 				FF9425951E28594B00FD8C24 /* SBAProfileFormStep.swift in Sources */,
 				FF2729111D9203D700956CFB /* SBAURLLearnMoreAction.swift in Sources */,
 				FF77F4721D4AC5E10005503E /* SBAMultipleLineTableViewCell.swift in Sources */,
 				FB0C9EF31CAA52F700BA5B44 /* Date+Utilities.swift in Sources */,
 				FF64111C1CB34766007FB9E1 /* SBAMedication.m in Sources */,
 				FFE57F241E393EFA00CEC67F /* SBANavigationSubtaskStep.swift in Sources */,
+				032D3E8B1F0EE07400AB8D33 /* SBAUnderlinedButton.swift in Sources */,
+				032D3E731F0EB3C200AB8D33 /* SBAGenericStepDataSource.swift in Sources */,
 				FF9055EC1CE527890049D12A /* SBAProgressStep.swift in Sources */,
 				FF6411161CB341D0007FB9E1 /* SBATrackedDataObject.m in Sources */,
 				FF5E56E61D6F8469008BA2A8 /* SBACheckmarkView.swift in Sources */,
 				FFCE30B31EBCFF9B0086DCAA /* SBAChoiceAnswerFormatProtocol.swift in Sources */,
 				FF9425751E2823FA00FD8C24 /* SBAInfoManager.m in Sources */,
 				FF2729151D92050100956CFB /* SBATrackedStepSurveyItem+Dictionary.swift in Sources */,
+				032D3E6A1F0EB1DE00AB8D33 /* SBAStepNavigationView.swift in Sources */,
 				FF0A880E1E8ADF1D00708A69 /* SBANameDataSource.swift in Sources */,
 				FF2729131D92045A00956CFB /* SBATextChoice+SBATrackedDataObject.swift in Sources */,
 				FF9425441E2812F100FD8C24 /* SBAConsentSharingOptions+Dictionary.swift in Sources */,
+				032D3E9D1F0FF4CC00AB8D33 /* SBAFormStep.swift in Sources */,
+				032D3E6E1F0EB29700AB8D33 /* SBAStepProgressView.swift in Sources */,
 				FF80920F1D01FD35003FF617 /* ORKAnswerFormat+KeyboardUtilities.swift in Sources */,
 				FF9425961E28594B00FD8C24 /* SBAProfileInfoForm.swift in Sources */,
 				FF2729091D92003700956CFB /* SBAChoice+String.swift in Sources */,
 				FFA8E4AF1CBD7CDA00ED5399 /* SBALoadingViewPresenter.swift in Sources */,
 				FF94256F1E281BC000FD8C24 /* ORKStep+ResultsExtension.swift in Sources */,
+				032D3E891F0ED72700AB8D33 /* SBAShadowGradient.swift in Sources */,
 				FF2729051D91FED900956CFB /* SBAChoice+Dictionary.swift in Sources */,
 				FF5CDF351DDE8D3600117218 /* SBAAnswerFormatFinder.swift in Sources */,
+				032D3E8E1F0EE35600AB8D33 /* UIColor+BridgeKeyNames.swift in Sources */,
 				FF9055DB1CE3E09C0049D12A /* UserDefaults+Utilities.swift in Sources */,
 				FFAAF6391CC0A42A00500929 /* SBABorderedButton.swift in Sources */,
+				032D3E851F0EBED000AB8D33 /* SBARoundedButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ResearchUXFactory/NSLayoutConstraint+setMultiplier.swift
+++ b/ResearchUXFactory/NSLayoutConstraint+setMultiplier.swift
@@ -1,0 +1,67 @@
+//
+//  NSLayoutConstraint+setMultiplier.swift
+//  elevateMS
+//
+//  Created by Josh Bruhin on 5/26/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+
+import Foundation
+import UIKit
+
+extension NSLayoutConstraint {
+    /**
+     Change the multiplier on a constraint by creating a new constraint with all the same
+     properties and the new multiplier
+     
+     @param multiplier  The new multipler value.
+     @return            A new constraint with the new multiplier value.
+     */
+    func setMultiplier(multiplier:CGFloat) -> NSLayoutConstraint {
+        
+        NSLayoutConstraint.deactivate([self])
+        
+        let newConstraint = NSLayoutConstraint(
+            item: firstItem,
+            attribute: firstAttribute,
+            relatedBy: relation,
+            toItem: secondItem,
+            attribute: secondAttribute,
+            multiplier: multiplier,
+            constant: constant)
+        
+        newConstraint.priority = priority
+        newConstraint.shouldBeArchived = self.shouldBeArchived
+        newConstraint.identifier = self.identifier
+        
+        NSLayoutConstraint.activate([newConstraint])
+        return newConstraint
+    }
+}

--- a/ResearchUXFactory/SBABaseSurveyFactory.swift
+++ b/ResearchUXFactory/SBABaseSurveyFactory.swift
@@ -233,7 +233,7 @@ open class SBABaseSurveyFactory : NSObject {
             // If this is *not* a subtask step and it uses navigation then return a survey form step
             (!isSubtaskStep && inputItem.usesNavigation()) ? SBANavigationFormStep(inputItem: inputItem) :
             // Otherwise, use a form step
-            ORKFormStep(identifier: inputItem.identifier)
+            SBAFormStep(identifier: inputItem.identifier)
         
         inputItem.buildFormItems(with: step as! SBAFormStepProtocol, isSubtaskStep: isSubtaskStep, factory: self)
         inputItem.mapStepValues(with: step)
@@ -317,8 +317,7 @@ open class SBABaseSurveyFactory : NSObject {
         switch (subtype) {
             
         case .visual:
-            return ORKVisualConsentStep(identifier: inputItem.identifier,
-                                        document: self.consentDocument)
+            return SBAVisualConsentStep(identifier: inputItem.identifier, consentDocument: self.consentDocument)
             
         case .sharingOptions:
             let share = inputItem as! SBAConsentSharingOptions

--- a/ResearchUXFactory/SBAFormStep.swift
+++ b/ResearchUXFactory/SBAFormStep.swift
@@ -3,7 +3,33 @@
 //  ResearchUXFactory
 //
 //  Created by Josh Bruhin on 7/7/17.
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 import UIKit

--- a/ResearchUXFactory/SBAFormStep.swift
+++ b/ResearchUXFactory/SBAFormStep.swift
@@ -1,0 +1,16 @@
+//
+//  SBAFormStep.swift
+//  ResearchUXFactory
+//
+//  Created by Josh Bruhin on 7/7/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+
+import UIKit
+
+class SBAFormStep: ORKFormStep {
+    
+    override func stepViewControllerClass() -> AnyClass {
+        return SBAGenericStepViewController.classForCoder()
+    }
+}

--- a/ResearchUXFactory/SBAGenericPageStepViewController.swift
+++ b/ResearchUXFactory/SBAGenericPageStepViewController.swift
@@ -1,0 +1,67 @@
+//
+//  SBAGenericPageStepViewController.swift
+//  ResearchUXFactory
+//
+//  Created by Josh Bruhin on 6/13/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+
+import UIKit
+
+class SBAGenericPageStepViewController: ORKPageStepViewController, UIPageViewControllerDelegate {
+    
+    override func stepViewController(for step: ORKStep) -> ORKStepViewController {
+        
+        // return our Generic Step VC
+        let stepVC = SBAGenericStepViewController(step: step, result: nil)
+        
+        if let pageStep = self.step as? ORKPageStep {
+            
+            // set progress on the view
+            stepVC.stepCount = pageStep.steps.count
+            stepVC.stepIndex = pageStep.steps.index(of: step)! + 1
+        }
+        
+        return stepVC
+        
+    }
+    
+    // TODO: Josh Bruhin, 6-13-17 - find a way to optionally remove the leftBarButtonItem.
+    // Our configuration has an option to show our back button in the navigationView instead of the
+    // navigationBar. Normally, this is done at the SBAGenericStepViewController level, but when a
+    // pageViewController is being used - like for consent - it's done at that level. So, we need to
+    // be able to check our configuration and optionally remove the leftBarButtonItem.
+    
+    // Problem is, super sets the leftBarButtonItem in the completion block of its pageViewController.setViewControllers()
+    // method, which fires after all the potential overridable methods we have. This also fires after the
+    // viewWillAppear() method of the stepVC for each scene, which is too bad because we could do it
+    // there, too. We could just override super's goToStep() method, but there's a fair bit of functionality
+    // there using some stuff we don't have access to.
+}

--- a/ResearchUXFactory/SBAGenericStepDataSource.swift
+++ b/ResearchUXFactory/SBAGenericStepDataSource.swift
@@ -1,0 +1,614 @@
+//
+//  SBAGenericStepDataSource.swift
+//  ResearchUXFactory
+//
+//  Created by Josh Bruhin on 6/5/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+/**
+ SBAGenericStepDataSource: the internal model for SBAGenericStepViewController. It provides the UITableViewDataSource,
+ manages and stores answers provided thru user input, and provides an ORKResult with those anwers upon request.
+ 
+ It also provides several convenience methods for saving or selecting answers, checking if all answers are valid,
+ and retrieving specific model objects that may be needed by the ViewController.
+ 
+ The tableView data source is comprised of 3 objects:
+ 
+ 1) SBAGenericStepTableSection - An object representing a section in the tableView. It has one or more SBAGenericStepTableItemGroups.
+ 
+ 2) SBAGenericStepTableItemGroup - An object representing a specific question supplied by ORKStep in the form of ORKFormItem.
+ An ORKFormItem can have multiple answer options, such as a boolean question or text choice
+ question. Or, it can have just one answer option, in the case of alpha/numeric questions.
+ 
+ Upon init(), the ItemGroup will create one or more SBAGenericStepTableItem representing the answer
+ options for the ORKFormItem. The ItemGroup is responsible for storing/computing the answers
+ for its ORKFormItem.
+ 
+ 3) SBAGenericStepTableItem - An object representing a specific answer option from the ItemGroup (ORKFormItem), such as a Yes or No
+ choice in a boolean question or a string or number that's entered thru a text field. There will be
+ one TableItem for each indexPath in the tableView.
+ */
+
+public protocol SBAGenericStepDataSourceDelegate {
+    func answersDidChange()
+}
+
+open class SBAGenericStepDataSource: NSObject {
+    
+    open var delegate: SBAGenericStepDataSourceDelegate?
+    open var sections: Array<SBAGenericStepTableSection> = Array()
+    open var step: ORKStep?
+    
+    /**
+     Initialize a new SBAGenericStepDataSource.
+     @param  step       The ORKStep
+     @param  result     The previous ORKResult, if any
+     */
+    public init(step: ORKStep?, result: ORKResult?) {
+        super.init()
+        self.step = step
+        populate()
+        if result != nil {
+            updateAnswers(from: result!)
+        }
+    }
+    
+    func updateAnswers(from result: ORKResult) {
+        
+        // iterate the provided results, find the corresponding ItemGroup for each, and save the answer
+        // provided in the results
+        
+        if let stepResult = result as? ORKStepResult {
+            if let results = stepResult.results as? Array<ORKQuestionResult> {
+                for result in results {
+                    let answer = result.answer ?? ORKNullAnswerValue()
+                    if let group = itemGroup(with: result.identifier) {
+                        group.answer = answer as AnyObject
+                    }
+                }
+            }
+        }
+    }
+    
+    
+    public func updateDefaults(_ defaults: NSMutableDictionary) {
+        
+        // TODO: Josh Bruhin, 6/12/17 - implement. this may require access to a HealthKit source.
+        // This has not yet been needed for the onboarding flow
+        
+        for section in sections {
+            section.itemGroups.forEach({
+                if let newAnswer = defaults[$0.formItem.identifier] {
+                    $0.defaultAnswer = newAnswer as AnyObject
+                }
+            })
+        }
+        
+        // notify our delegate that the result changed
+        if let delegate = delegate {
+            delegate.answersDidChange()
+        }
+    }
+    
+    /**
+     Determine if all answers are valid. Also checks the case where answers are required but one has not been provided.
+     @return    A Bool indicating if all answers are valid
+     */
+    open func allAnswersValid() -> Bool {
+        for section in sections {
+            for itemGroup in section.itemGroups {
+                if !itemGroup.isAnswerValid {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+    
+    /**
+     Retrieve the 'SBAGenericStepTableItemGroup' with a specific ORKFormItem identifier.
+     @param   identifier   The identifier of the ORKFormItem assigned to the ItemGroup
+     @return               The requested SBAGenericStepTableItemGroup, or nil if it cannot be found
+     */
+    open func itemGroup(with identifier: String) -> SBAGenericStepTableItemGroup? {
+        for section in sections {
+            for itemGroup in section.itemGroups {
+                if itemGroup.formItem.identifier == identifier {
+                    return itemGroup
+                }
+            }
+        }
+        return nil
+    }
+    
+    /**
+     Retrieve the 'SBAGenericStepTableItemGroup' for a specific IndexPath.
+     @param   indexPath   The IndexPath that represents the ItemGroup in the tableView
+     @return              The requested SBAGenericStepTableItemGroup, or nil if it cannot be found
+     */
+    open func itemGroup(at indexPath: IndexPath) -> SBAGenericStepTableItemGroup? {
+        let section = sections[indexPath.section]
+        for itemGroup in section.itemGroups {
+            if itemGroup.beginningRowIndex ... itemGroup.beginningRowIndex + (itemGroup.items.count - 1) ~= indexPath.row {
+                return itemGroup
+            }
+        }
+        return nil
+    }
+    
+    /**
+     Retrieve the 'SBAGenericStepTableItem' for a specific IndexPath.
+     @param   indexPath   The IndexPath that represents the TableItem in the tableView
+     @return              The requested SBAGenericStepTableItem, or nil if it cannot be found
+     */
+    open func tableItem(at indexPath: IndexPath) -> SBAGenericStepTableItem? {
+        if let itemGroup = itemGroup(at: indexPath) {
+            let index = indexPath.row - itemGroup.beginningRowIndex
+            return itemGroup.items[index]
+        }
+        return nil
+    }
+    
+    /**
+     Save an answer for a specific IndexPath.
+     @param   answer      The object to be save as the answer
+     @param   indexPath   The IndexPath that represents the TableItemGroup in the tableView
+     */
+    open func saveAnswer(_ answer: AnyObject, at indexPath: IndexPath) {
+        
+        let itemGroup = self.itemGroup(at: indexPath)
+        itemGroup?.answer = answer
+        
+        // inform delegate that answers have changed
+        if let delegate = delegate {
+            delegate.answersDidChange()
+        }
+    }
+    
+    /**
+     Select or deselect the answer option for a specific IndexPath.
+     @param   indexPath   The IndexPath that represents the TableItemGroup in the tableView
+     */
+    open func selectAnswer(selected: Bool, at indexPath: IndexPath) {
+        
+        let itemGroup = self.itemGroup(at: indexPath)
+        itemGroup?.select(selected, indexPath: indexPath)
+        
+        // inform delegate that answers have changed
+        if let delegate = delegate {
+            delegate.answersDidChange()
+        }
+    }
+    
+    /**
+     Retrieve the current ORKStepResult.
+     @return    An ORKStepResult object with the current answers for all of its ORKFormItems
+     */
+    open func results(parentResult: ORKStepResult) -> ORKStepResult {
+        
+        if let formItems = formItemsWithAnswerFormat() {
+            
+            // "Now" is the end time of the result, which is either actually now,
+            // or the last time we were in the responder chain.
+            
+            let now = parentResult.endDate
+            var qResults: Array<ORKResult> = Array()
+            
+            for formItem: ORKFormItem in formItems {
+                
+                
+                // Skipped forms report a "null" value for every item -- by skipping, the user has explicitly said they don't want
+                // to report any values from this form.
+                
+                var answer = ORKNullAnswerValue()
+                var answerDate = now
+                var systemCalendar = Calendar.current
+                var systemTimeZone = NSTimeZone.system
+                
+                // TODO: Josh Bruhin, 6/12/17 - implement skipped?
+                let skipped = false
+                if !skipped {
+                    
+                    if let itemGroup = itemGroup(with: formItem.identifier) {
+                        answer = itemGroup.answer
+                        answerDate = itemGroup.answerDate ?? now
+                        systemCalendar = itemGroup.calendar
+                        systemTimeZone = itemGroup.timezone
+                    }
+                }
+                
+                let result = formItem.answerFormat?.result(withIdentifier: formItem.identifier, answer: answer)
+                let impliedAnswerFormat = formItem.answerFormat?.implied()
+                
+                if let dateAnswerFormat = impliedAnswerFormat as? ORKDateAnswerFormat, let dateQuestionResult = result as? ORKDateQuestionResult {
+                    if let _ = dateQuestionResult.dateAnswer {
+                        let usedCalendar = dateAnswerFormat.calendar ?? systemCalendar
+                        dateQuestionResult.calendar = usedCalendar
+                        dateQuestionResult.timeZone = systemTimeZone
+                    }
+                } else if let numericAnswerFormat = impliedAnswerFormat as? ORKNumericAnswerFormat {
+                    if let numericQuestionFormat = result as? ORKNumericQuestionResult {
+                        numericQuestionFormat.unit = numericAnswerFormat.unit
+                    }
+                }
+                
+                result?.startDate = answerDate
+                result?.endDate = answerDate
+                
+                qResults.append(result!)
+            }
+            
+            parentResult.results = parentResult.results! + qResults
+        }
+        
+        return parentResult
+    }
+    
+    fileprivate func formItemsWithAnswerFormat() -> Array<ORKFormItem>? {
+        
+        if let formItems = formItems() {
+            var items: Array<ORKFormItem> = Array()
+            formItems.forEach({
+                if let _ = $0.answerFormat {
+                    items.append($0)
+                }
+            })
+            return items
+        }
+        return nil
+    }
+    
+    fileprivate func formItems() -> Array<ORKFormItem>? {
+        switch self.step {
+        case is ORKFormStep:
+            return (self.step as! ORKFormStep).formItems
+        case is ORKQuestionStep:
+            return (self.step as! ORKQuestionStep).formItems
+        default:
+            return nil
+        }
+    }
+    
+    fileprivate func populate() {
+        
+        if let items = formItems(), items.count > 0 {
+            
+            let singleSelectionTypes: Array<Int> = [ORKQuestionType.boolean.rawValue,
+                                                    ORKQuestionType.singleChoice.rawValue,
+                                                    ORKQuestionType.multipleChoice.rawValue,
+                                                    ORKQuestionType.location.rawValue]
+            
+            var newSection: SBAGenericStepTableSection? = nil
+            
+            for item in items {
+                
+                // In case no section available, create new one.
+                if newSection == nil {
+                    newSection = SBAGenericStepTableSection(sectionIndex: sections.count)
+                }
+                
+                if let answerFormat = item.answerFormat?.implied() {
+                    let multiCellChoices = singleSelectionTypes.contains(answerFormat.questionType.rawValue) && type(of: answerFormat) != ORKValuePickerAnswerFormat.self
+                    let multiLineTextEntry = answerFormat.questionType == .text
+                    let scale = answerFormat.questionType == .scale
+                    
+                    
+                    if multiCellChoices || multiLineTextEntry || scale {
+                        
+                        newSection!.title = item.text
+                        newSection!.add(formItem: item)
+                        sections.append(newSection!)
+                        
+                        // following item should start a new section
+                        newSection = nil
+                    }
+                    else {
+                        
+                        newSection!.add(formItem: item)
+                        sections.append(newSection!)
+                    }
+                }
+                else {
+                    
+                    newSection!.title = item.text
+                    sections.append(newSection!)
+                }
+            }
+        }
+        
+    }
+}
+
+
+open class SBAGenericStepTableSection: NSObject {
+    
+    open var itemGroups: Array<SBAGenericStepTableItemGroup> = Array()
+    
+    private var _title: String?
+    var title: String? {
+        get { return _title }
+        set (newValue) { _title = newValue?.uppercased(with: Locale.current) }
+    }
+    
+    var index: Int?
+    
+    public init(sectionIndex: Int) {
+        index = sectionIndex
+    }
+    
+    /**
+     Add a new ORKFormItem, which results in the creation and addition of a new SBAGenericStepTableItemGroup to the section.
+     The ItemGroup essectially represents the FormItem and is reponsible for storing and providing answers for the FormItem
+     when a ORKStepResult is requested.
+     
+     @param   formItem    The ORKFormItem to add to the section
+     */
+    public func add(formItem: ORKFormItem) {
+        itemGroups.append(SBAGenericStepTableItemGroup(formItem: formItem, beginningRowIndex: itemCount()))
+    }
+    
+    /**
+     Returns the total count of all Items in this section.
+     @return    The total number of SBAGenericStepTableItems in this section
+     */
+    public func itemCount() -> Int {
+        var count = 0
+        itemGroups.forEach({ count += $0.items.count })
+        return count
+    }
+}
+
+
+open class SBAGenericStepTableItemGroup: NSObject {
+    
+    let formItem: ORKFormItem!
+    
+    var items: Array<SBAGenericStepTableItem> = Array()
+    var beginningRowIndex = 0
+    
+    // TODO: Josh Bruhin, 6/12/17 - implement multi-selection formItems. For now, set to singleSelection
+    var singleSelection: Bool = true
+    
+    var answerDate: Date?
+    var calendar = Calendar.current
+    var timezone = TimeZone.current
+    
+    var defaultAnswer: AnyObject = ORKNullAnswerValue() as AnyObject
+    var _answer: AnyObject?
+    
+    /**
+     Save an answer for this ItemGroup (FormItem). This is used only for those questions that have single answers,
+     such as text and numeric answers, as opposed to booleans or text choice answers.
+     */
+    public var answer: AnyObject! {
+        get { return internalAnswer() }
+        set { setInternalAnswer(newValue) }
+    }
+    
+    /**
+     Determine if the current answer is valid. Also checks the case where answer is required but one has not been provided.
+     @return    A Bool indicating if answer is valid
+     */
+    public var isAnswerValid: Bool {
+        
+        var valid = true
+        
+        // if answewr is NOT optional and it equals Null (ORKNullAnswerValue()), or is nil, then it's invalid
+        if !formItem.isOptional, answer is NSNull || answer == nil {
+            valid = false
+        }
+        
+        // also check the value
+        if !formItem.answerFormat!.implied().isAnswerValid(answer) {
+            valid = false
+        }
+        return valid
+    }
+    
+    /**
+     Initialize a new ItemGroup with an ORKFormItem. Pass a beginningRowIndex since sections can have multiple ItemGroups.
+     @param  formItem   The ORKFormItem to add to the model
+     @param  beginningRowIndex  The row index in the section at which this formItem begins
+     */
+    fileprivate init(formItem: ORKFormItem, beginningRowIndex: Int) {
+        
+        self.formItem = formItem
+        
+        super.init()
+        
+        var rowIndex = beginningRowIndex
+        
+        if let textChoiceAnswerFormat = formItem.answerFormat?.implied() as? ORKTextChoiceAnswerFormat {
+            
+            textChoiceAnswerFormat.textChoices.forEach({
+                let index = textChoiceAnswerFormat.textChoices.index(of: $0)!
+                let tableItem = SBAGenericStepTableItem(formItem: formItem, choiceIndex: index, rowIndex: rowIndex)
+                items.append(tableItem)
+                rowIndex += 1
+            })
+        } else {
+            let tableItem = SBAGenericStepTableItem(formItem: formItem, choiceIndex: 0, rowIndex: rowIndex)
+            items.append(tableItem)
+        }
+    }
+    
+    /**
+     Select or de-select an item (answer) at a specific indexPath. This is used for text choice and boolean answers.
+     @param  selected   A bool indicating if item should be selected
+     @param  indexPath  The IndexPath of the item
+     */
+    fileprivate func select(_ selected: Bool, indexPath: IndexPath) {
+        
+        // to get index of our item, add our beginningRowIndex to indexPath.row
+        let index = beginningRowIndex + indexPath.row
+        if items.count > index {
+            items[index].selected = selected
+        }
+        
+        // if we selected an item and this is a single-selection group, then we iterate
+        // our other items and de-select them
+        
+        if selected && singleSelection {
+            items.forEach({
+                if $0 != items[index] { $0.selected = false }
+            })
+        }
+    }
+    
+    fileprivate func internalAnswer() -> AnyObject {
+        
+        if items.count > 0 {
+            
+            let answerFormat = items[0].formItem?.answerFormat
+            switch answerFormat {
+            case is ORKBooleanAnswerFormat:
+                return answerForBoolean()
+                
+            case is ORKMultipleValuePickerAnswerFormat,
+                 is ORKTextChoiceAnswerFormat:
+                return answerForTextChoice()
+                
+            default:
+                return _answer ?? defaultAnswer
+            }
+        }
+        return _answer ?? defaultAnswer
+    }
+    
+    fileprivate func setInternalAnswer(_ answer: AnyObject) {
+        
+        if items.count > 0 {
+            
+            let answerFormat = items[0].formItem?.answerFormat
+            switch answerFormat {
+            case is ORKBooleanAnswerFormat:
+                
+                // iterate our items and find the item with a value equal to our answer,
+                // then select that item
+                
+                let formattedAnswer = answer as? NSNumber
+                for item in items {
+                    if (item.choice?.value as? NSNumber)?.boolValue == formattedAnswer?.boolValue {
+                        item.selected = true
+                    }
+                }
+                
+            case is ORKTextChoiceAnswerFormat:
+                
+                // iterate our items and find the items with a value that is contained in our
+                // answer, which should be an array, then select those items
+                
+                if let arrayAnswer = answer as? Array<AnyObject> {
+                    for item in items {
+                        for selectedValue in arrayAnswer {
+                            if let choiceString = item.choice?.value as? String, let selectedString = selectedValue as? String {
+                                item.selected = choiceString == selectedString
+                            }
+                            else if let choiceNumber = item.choice?.value as? NSNumber, let selectedNumber = selectedValue as? NSNumber {
+                                item.selected = choiceNumber.intValue == selectedNumber.intValue
+                            }
+                        }
+                    }
+                }
+                
+            case is ORKMultipleValuePickerAnswerFormat:
+                
+                // TODO: Josh Bruhin, 6/12/17 - implement this answer format.
+                fatalError("setInternalAnswer for ORKMultipleValuePickerAnswerFormat not implemented")
+                
+            default:
+                _answer = answer
+            }
+        }
+    }
+    
+    private func answerForTextChoice() -> AnyObject {
+        var array: Array<AnyObject> = Array()
+        for item in items {
+            if item.selected {
+                array.append(item.choice!.value)
+            }
+        }
+        return array.count > 0 ? array as AnyObject : ORKNullAnswerValue() as AnyObject
+    }
+    
+    private func answerForBoolean() -> AnyObject {
+        for item in items {
+            if item.selected {
+                if let value = item.choice?.value as? NSNumber {
+                    return NSDecimalNumber(value: value.boolValue)
+                }
+            }
+        }
+        return ORKNullAnswerValue() as AnyObject
+    }
+}
+
+open class SBAGenericStepTableItem: NSObject {
+    
+    // the same formItem assigned to the group that this item belongs to
+    var formItem: ORKFormItem?
+    var answerFormat: ORKAnswerFormat?
+    var choice: ORKTextChoice?
+    
+    var choiceIndex = 0
+    var rowIndex = 0
+    
+    var selected: Bool = false
+    
+    /**
+     Initialize a new SBAGenericStepTableItem
+     @param   formItem      The ORKFormItem representing this tableItem.
+     @param   choiceIndex   The index of this item relative to all the choices in this ItemGroup
+     @param   rowIndex      The index of this item relative to all rows in the section in which this item resides
+     */
+    fileprivate init(formItem: ORKFormItem!, choiceIndex: Int, rowIndex: Int) {
+        super.init()
+        commonInit(formItem: formItem)
+        self.choiceIndex = choiceIndex
+        self.rowIndex = rowIndex
+        if let textChoiceFormat = textChoiceAnswerFormat() {
+            choice = textChoiceFormat.textChoices[choiceIndex]
+        }
+    }
+    
+    func commonInit(formItem: ORKFormItem!) {
+        self.formItem = formItem
+        self.answerFormat = formItem.answerFormat?.implied()
+    }
+    
+    func textChoiceAnswerFormat() -> ORKTextChoiceAnswerFormat? {
+        guard let textChoiceFormat = self.answerFormat as? ORKTextChoiceAnswerFormat else { return nil }
+        return textChoiceFormat
+    }
+}
+

--- a/ResearchUXFactory/SBAGenericStepViewController.swift
+++ b/ResearchUXFactory/SBAGenericStepViewController.swift
@@ -1,0 +1,881 @@
+//
+//  SBAGenericStepViewController.swift
+//  ResearchUXFactory
+//
+//  Created by Josh Bruhin on 5/16/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+
+import UIKit
+
+/**
+ SBAGenericStepViewController: A custom instance of ORKStepViewController. Its subviews include a UITableView,
+ an SBAStepNavigationView, which may or may not be 'embedded' in the tableView as its footerView, and
+ an SBAStepHeaderView, which is 'embedded' in the tableView as its headerView.
+ 
+ This class populates the contents and properties of the headerView and navigationView based on ORKStep, which is
+ supplied upon init(). This is done in setupViews(), which is also where the tableView is created.
+ 
+ An instance of SBAGenericStepDataSource is created upon init() and is the UITableViewDataSource. It's based on
+ ORKStep and is assigned to property tableData. The tableData also keeps track of answers that are derived
+ from the user's input and it provides the ORKResult to our delegate.
+ 
+ This class is responsible for acquiring input from the user, validating it, and supplying it as an answer to
+ to the model (tableData). This is typically done in delegate call backs from various input views, such as
+ UITableView (didSelectRow) or UITextField (valueDidChange or shouldChangeCharactersInRange).
+ 
+ Some ORKSteps, such as ORKInstructionStep, require no user input (and have no ORKFormItems). These steps
+ will result in tableData that has no sections and, therefore, no rows. So the tableView will simply have a
+ headerView, no rows, and a footerView.
+ 
+ To customize the view elements, subclasses should override the initializeViews() method. This will allow
+ the use of any custom element (of the appropriate type) to be used instead of the default instances. To just
+ customize the appearance or properties of the headerView and navigationView, subclasses can simply override
+ setupHeaderView() and setupNavigationView().
+ */
+
+
+open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataSource, UITableViewDelegate, UITextFieldDelegate, SBAGenericStepDataSourceDelegate {
+    
+    private let kMainViewBottomMargin: CGFloat = 30.0
+    private let kDefaultRowHeight: CGFloat = 75.0
+    private let kFormStepMinHeaderHeight: CGFloat = 180
+    
+    private var navigationViewHeight: CGFloat = 0.0
+    private var savedVerticalScrollOffet: CGFloat = 0.0
+    private let useStickyNavView = SBAGenericStepUIConfig.shouldUseStickyNavigationView()
+    
+    private let kEstimatedRowHeight: CGFloat = 100
+
+    open var tableData: SBAGenericStepDataSource?
+    open var tableView: UITableView?
+    open var headerView: SBAStepHeaderView?
+    open var navigationView: SBAStepNavigationView?
+    
+    // we keep a copy of the original result after initialization so we can return that if the user
+    // does not continue to the next step instead of returning any answers they might have given before
+    // closing or cancelling
+    
+    var originalResult: ORKStepResult!
+    var userHasContinued = false
+    
+    
+    var tableViewInsetBottom: CGFloat {
+        get {
+            return useStickyNavView ? navigationViewHeight + constants().mainViewBottomMargin : constants().mainViewBottomMargin
+        }
+    }
+    
+    lazy var numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = Int(NSDecimalNoScale)
+        formatter.usesGroupingSeparator = true
+        return formatter;
+    }()
+    
+    
+    /**
+     Index of this step in the current flow. Will cause the progressView in the headerView to be updated
+     */
+    public var stepIndex: Int = 0 {
+        didSet {
+            headerView?.progressView.currentStep = stepIndex
+        }
+    }
+    
+    /**
+     Total number of steps in the current flow. Will cause the progressView in the headerView to be updated
+     */
+    public var stepCount: Int = 0 {
+        didSet {
+            headerView?.progressView.totalSteps = stepCount
+        }
+    }
+    
+    
+    // Override result so we can generate our own result from our internal model
+    override open var result: ORKStepResult? {
+        get { return customResult() }
+    }
+    
+    
+    // MARK: Initializers
+    
+    override public init(step: ORKStep, result: ORKResult?) {
+        super.init(step: step)
+        commonInit(with: result)
+    }
+    
+    override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit(with: nil)
+    }
+    
+    func commonInit(with result: ORKResult?) {
+        setupModel(with: result)
+    }
+    
+    
+    // MARK: View lifecycle
+    
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // register for keyboard notifications
+        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardNotification(notification:)), name: NSNotification.Name.UIKeyboardWillChangeFrame, object: nil)
+        
+        // show or hide our navigation bar
+        navigationController?.setNavigationBarHidden(!shouldShowNavigationBar(), animated: false)
+        
+        setupViews()
+    }
+        
+    override open func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        NotificationCenter.default.removeObserver(self)
+        
+        // Dismiss all textField's keyboard
+        tableView?.endEditing(false)
+    }
+    
+    override open func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // need to do this here because when the navView is generated, our delegate has not yet been set
+        // so we don't know answers on whether or not there are previous or next steps
+        
+        navigationView?.nextButton.isHidden = !hasNextStep()
+        navigationView?.previousButton.isHidden = !hasPreviousStep()
+        
+        // update enabled state of next button
+        navigationView?.nextButton.isEnabled = shouldEnableNextButton()
+        
+        // setup nav bar because this is where super does it and we need to override
+        setupNavBar()
+    }
+    
+    override open func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        // if we have no tableView or navigationView, then nothing to do
+        guard let tableView = tableView, let navigationView = navigationView else {
+            return
+        }
+        
+        // need to save height of our nav view so it can be used to calculate the bottom inset (margin)
+        navigationViewHeight = navigationView.systemLayoutSizeFitting(UILayoutFittingCompressedSize).height
+        
+        let totalHeight = tableView.contentSize.height + navigationViewHeight
+        let contentSizeExceedsTableHeight = totalHeight > tableView.frame.size.height
+        
+        if !useStickyNavView && contentSizeExceedsTableHeight {
+            
+            // put the navView in the tableView as it's footerView
+            // we need to add the view as the footer view, get it's height, reset the views frame,
+            // then add as the table's footerView again. This is because the view height is dynamic
+            // and the tableView won't adjust it's height dynamically otherwise
+            
+            navigationView.translatesAutoresizingMaskIntoConstraints = true
+            tableView.tableFooterView = navigationView
+            navigationView.frame = CGRect(x: 0, y: 0, width: navigationView.frame.size.width, height: navigationViewHeight)
+            tableView.tableFooterView = navigationView
+        }
+        else {
+            
+            // pin navView to bottom of screen
+            navigationView.translatesAutoresizingMaskIntoConstraints = false
+            
+            view.addSubview(navigationView)
+            navigationView.alignToSuperview([.leading, .trailing, .bottom], padding: 0.0)
+            
+            // we also need to add an invisible view as the table's footerview so we don't get
+            // a bunch of empty rows
+            
+            let footerView = UIView()
+            footerView.backgroundColor = UIColor.clear
+            tableView.tableFooterView = footerView
+            
+            // show the shadow only if our content size is big enough for content to underlap the shadow
+            navigationView.shouldShowShadow = contentSizeExceedsTableHeight
+        }
+        
+        // set the tableView bottom inset
+        var inset = tableView.contentInset
+        inset.bottom = tableViewInsetBottom
+        tableView.contentInset = inset
+    }
+    
+    // MARK: Model setup
+    
+    /**
+     Creates and assigns a new instance of our model, SBAGenericStepDataSource.
+     @param   result   The result that is provided upon init()
+     */
+    open func setupModel(with result: ORKResult?) {
+        tableData = SBAGenericStepDataSource(step: step, result: result)
+        tableData?.delegate = self
+        
+        // we save our current result so we can return it if the user does not continue
+        // to the next step. If they do continue to the next step, then we get a new result
+        // from our model. This is done in customResult()
+        
+        originalResult = tableData?.results(parentResult: super.result!)
+    }
+    
+    /**
+     Get updated results from our model, adding to the current result from super, or returns
+     our originalResult if the user has not continued to the next step.
+     @return    The latest ORKStepResult
+     */
+    open func customResult() -> ORKStepResult! {
+        return userHasContinued ? tableData!.results(parentResult: super.result!) : originalResult
+    }
+    
+    
+    // MARK: View setup
+    
+    // override super's stepDidChange. We don't want to call super here because this is where
+    // all of it's view elements are setup, which we aren't using.
+    func customStepDidChange() {
+        // nothing
+    }
+    
+    /**
+     Create all the view elements. Subclasses can override to provide custom instances. A customView
+     can optionally be created here by the subclass.
+     */
+    open func initializeViews() {
+        headerView = SBAStepHeaderView()
+        navigationView = SBAStepNavigationView()
+    }
+    
+    open func setupNavBar() {
+        
+        // setup back button
+        let showBackButton = SBAGenericStepUIConfig.backButtonPosition() == .navigationBar
+        if !showBackButton {
+            
+            // if we are being displayed in a page view controller, then we will not be able to remove
+            // our back button becuase it is set at the page VC level. So we test our delegate to see
+            // if it is a page VC and, if it is, we get a reference to it and remove the back button
+            
+            if let pageViewController = self.delegate as? SBAGenericPageStepViewController {
+                pageViewController.navigationItem.leftBarButtonItem = nil
+            } else {
+                navigationItem.leftBarButtonItem = nil
+            }
+        } else {
+            // super provides a back button when needed, so we just use it
+        }
+    }
+    
+    open func setupViews() {
+        
+        initializeViews()
+        
+        tableView = UITableView(frame: view.bounds, style: .plain)
+        tableView?.delegate = self
+        tableView?.dataSource = self
+        tableView?.rowHeight = UITableViewAutomaticDimension
+        tableView?.sectionHeaderHeight = 0.0
+        tableView?.estimatedRowHeight = constants().defaultRowHeight
+        tableView?.estimatedSectionHeaderHeight = 0.0
+        tableView?.separatorStyle = .none
+        
+        tableView?.rowHeight = UITableViewAutomaticDimension
+        tableView?.estimatedRowHeight = kEstimatedRowHeight
+
+        view.addSubview(tableView!)
+        
+        tableView?.translatesAutoresizingMaskIntoConstraints = false
+        tableView?.alignAllToSuperview(padding: 0.0)
+        
+        // setup our header view
+        setupHeaderView(headerView!)
+        
+        // to get the tableView to size the headerView properly, we have to get the headerView height
+        // and manually set the frame with that height
+        
+        let headerHeight = headerView!.systemLayoutSizeFitting(UILayoutFittingCompressedSize).height
+        headerView?.frame = CGRect(x: 0, y: 0, width: headerView!.frame.size.width, height: headerHeight)
+        tableView?.tableHeaderView = headerView
+                
+        // setup the navigationView. we don't add it to the view yet because it may have to
+        // be placed as the tableView's footerView or it may be added to the main view and pinned
+        // to the bottom. This depends on the eventual frame size of the tableView, so we need to
+        // wait until viewDidLayoutSubviews() so we know what the height will be
+        
+        setupNavigationView(navigationView)
+    }
+    
+    /**
+     Auto layout constraint constants for the margin used at the bottom of the main view
+     and the default tableView row height.
+     @return    A struct with the layout constants
+     */
+    open func constants() -> (mainViewBottomMargin: CGFloat, defaultRowHeight: CGFloat, formStepMinHeaderHeight: CGFloat) {
+        
+        // we only need some bottom margin if we have any table data (rows), otherwise, the bottom
+        // margin built into the headerView is enough
+        
+        return (tableView!.numberOfSections > 0 ? kMainViewBottomMargin : 0.0,
+                kDefaultRowHeight,
+                kFormStepMinHeaderHeight)
+    }
+    
+    /**
+     Specifies whether the navigation bar should be shown.
+     @return    A Bool indicating if next navigation bar should be shown
+     */
+    open func shouldShowNavigationBar() -> Bool {
+        return true
+    }
+    
+    /**
+     Specifies whether the next button should be enabled based on the validity of the answers for
+     all form items. If tableData is nil, then false is returned.
+     
+     @return    A Bool indicating if next button should be enabled
+     */
+    open func shouldEnableNextButton() -> Bool {
+        guard let tableData = tableData else { return false }
+        return tableData.allAnswersValid()
+    }
+    
+    /**
+     Specifies whether the learn more button should be shown.
+     @return    A Bool indicating if button should be shown
+     */
+    open func shouldShowLearnMore() -> Bool {
+        
+        if let learnMoreStep = step as? SBALearnMoreActionStep, learnMoreStep.learnMoreAction != nil {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    /**
+     Populates and configures the internal properties of an SBAStepHeaderView.
+     @param   headView   the SBAStepHeaderView to configure
+     */
+    open func setupHeaderView(_ headView: SBAStepHeaderView) {
+        
+        if let instructionStep = step as? ORKInstructionStep {
+            // set image, check for both .image and .iconImage
+            if let image = instructionStep.image {
+                headView.image = image
+            }
+            else if let image = instructionStep.iconImage {
+                headView.image = image
+            }
+        }
+        
+        // setup progress
+        headView.progressView.totalSteps = stepCount
+        headView.progressView.currentStep = stepIndex
+        
+        
+        // setup label text
+        headView.headerLabel.text = step?.title
+        headView.detailsLabel.text = step?.text
+        
+        
+        // populate 'prompt' label if we have any text
+        // TODO: Josh Bruhin, 6/12/17 - currently, if we have a form step, we use the 'footnote'
+        // property. Using 'footnote' may not work because that's used for Sage
+        // copyright-type info on the registration step. We may want a dedicated field in the
+        // model for this. Maybe we subclass SBANavigableFormStep and add a 'prompt' property?
+        
+        if let formStep = step as? ORKFormStep {
+            headView.promptLabel.text = formStep.footnote
+        }
+        
+        // learn more button
+        if shouldShowLearnMore() {
+            
+            headView.shouldShowLearnMore = true
+            
+            // add our action
+            headView.learnMoreButton.addTarget(self, action: #selector(showLearnMore), for: .touchUpInside)
+            
+            // set the title
+            headView.learnMoreButton.setTitle(learnMoreButtonTitle ?? Localization.buttonLearnMore(), for: .normal)
+        }
+        
+        if step is ORKFormStep {
+            
+            // We have a minimum height for ORKFormSteps because these step usually have just a title and
+            // description and the design generally calls for quite a bit of margin above and below the labels.
+            // So we set a minimum size
+            
+            headView.minumumHeight = constants().formStepMinHeaderHeight
+        }
+    }
+    
+    /**
+     Populates and configures the internal properties of an SBAStepNavigationView.
+     @param   navView   the SBAStepNavigationView to configure
+     */
+    open func setupNavigationView(_ navView: SBAStepNavigationView?) {
+        navView?.backgroundColor = UIColor.white
+        
+        // setup the button actions
+        navView?.nextButton.addTarget(self, action: #selector(nextHit), for: .touchUpInside)
+        navView?.previousButton.addTarget(self, action: #selector(previousHit), for: .touchUpInside)
+        
+        // show or hide our prev and next buttons
+        navView?.nextButton.isHidden = !hasNextStep()
+        navView?.previousButton.isHidden = !hasPreviousStep()
+    }
+    
+    // MARK: Actions
+    
+    /**
+     The default action for the Next Button in the SBAStepNavigationView.
+     */
+    open func nextHit() {
+        
+        // need to indicate user has chosen to continue so the result will be updated
+        // with their answers, otherwise the orginal result will be returned
+        
+        userHasContinued = true
+        goForward()
+    }
+    
+    /**
+     The default action for the Previous Button in the SBAStepNavigationView.
+     */
+    open func previousHit() {
+        goBackward()
+    }
+    
+    /**
+     The default action for the Learn More Button in the SBAStepHeaderView.
+     */
+    open func showLearnMore() {
+        
+        guard let learnMoreStep = step as? SBALearnMoreActionStep, let learnMore = learnMoreStep.learnMoreAction else {
+            return
+        }
+        
+        // we need to get a reference to our ORKTaskViewController. In most cases, this will be
+        // our delegate, but it's possible our delegate will be a SBAGenericPageStepViewController.
+        // This is true for the consent scenes. If this is the case, then our delegate's delegate
+        // should be the ORKTaskViewController
+        
+        let taskVC: ORKTaskViewController?
+        
+        if let pageStepController = self.delegate as? SBAGenericPageStepViewController {
+            taskVC = pageStepController.delegate as? ORKTaskViewController
+        } else {
+            taskVC = self.delegate as? ORKTaskViewController
+        }
+        
+        if taskVC != nil {
+            learnMore.learnMoreAction(for: learnMoreStep, with: taskVC!)
+        }
+    }
+    
+    /**
+     The 'SBAStepTextFieldTableViewCell' to use. Override to provide a custom instances of this class.
+     @param     reuseIdentifier     A String representing the reuse identifier of the cell
+     @return                        The 'SBAStepTextFieldTableViewCell' class to use
+     */
+    open func textFieldCell(reuseIdentifier: String) -> SBAStepTextFieldTableViewCell {
+        return SBAStepTextFieldTableViewCell(style: .default, reuseIdentifier: reuseIdentifier)
+    }
+    
+    
+    // MARK: UITableView Datasource
+    
+    open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return tableData!.sections[section].itemCount()
+    }
+    open func numberOfSections(in tableView: UITableView) -> Int {
+        return tableData!.sections.count
+    }
+    
+    open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        // subclass may override
+        return nil
+    }
+    
+    open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        // subclass may override
+        return 0.0
+    }
+    
+    open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        let identifier = "\(indexPath.section)-\(indexPath.row)"
+        var cell = tableView.dequeueReusableCell(withIdentifier: identifier)
+        
+        let tableItem = tableData!.tableItem(at: indexPath)
+        let answerFormat = tableItem?.formItem?.answerFormat?.implied()
+        let type = answerFormat?.questionType
+        
+        if cell == nil {
+            
+            // configure cell
+            
+            if type == .decimal || type == .integer || type == .text {
+                
+                // Create a textField based cell
+                let fieldCell = textFieldCell(reuseIdentifier: identifier)
+                fieldCell.textField.delegate = self
+                fieldCell.selectionStyle = .none
+                
+                // setup our keyboard accessory view, which is a standard navigationView
+                let navView = SBAStepNavigationView()
+                setupNavigationView(navView)
+                
+                // update enabled state of the next button
+                navView.nextButton.isEnabled = tableData!.allAnswersValid()
+                
+                // using auto layout to constrain the navView to fill its superview after adding it to the textfield
+                // as its inputAccessoryView doesn't work for whatever reason. So we get the computed height from the
+                // navView and manually set its frame before assigning it to the text field
+                
+                let navHeight = navView.systemLayoutSizeFitting(UILayoutFittingCompressedSize).height
+                let navWidth = UIScreen.main.bounds.size.width
+                navView.frame = CGRect(x: 0, y: 0, width: navWidth, height: navHeight)
+                
+                fieldCell.textField.inputAccessoryView = navView
+                
+                // set keyboard type
+                if let textAnswerFormat = answerFormat as? ORKTextAnswerFormat {
+                    // use the keyboard type defined for this step
+                    fieldCell.textField.keyboardType = textAnswerFormat.keyboardType
+                }
+                else {
+                    // use the keyboard type appropriate for the questionType
+                    fieldCell.textField.keyboardType = type == .text ? .default : .numberPad
+                }
+                
+                cell = fieldCell
+                
+            } else {
+                
+                // Create a choice based cell
+                let choiceCell = SBAStepChoiceTableViewCell(style: .default, reuseIdentifier: identifier)
+                cell = choiceCell
+            }
+        }
+        
+        // populate cell
+        
+        if type == .decimal || type == .integer || type == .text {
+            
+            if let textFieldCell = cell as? SBAStepTextFieldTableViewCell {
+                
+                if let customField = textFieldCell.textField as? SBAStepTextField {
+                    customField.indexPath = indexPath
+                }
+                
+                // if we have an answer, populate the text field
+                let itemGroup = tableData!.itemGroup(at: indexPath)
+                if itemGroup!.isAnswerValid {
+                    if let answerNumber = itemGroup?.answer as? NSNumber {
+                        textFieldCell.textField.text = answerNumber.stringValue
+                    }
+                    else if let answerString = itemGroup?.answer as? String {
+                        textFieldCell.textField.text = answerString
+                    }
+                }
+            }
+        } else {
+            if let choiceCell = cell as? SBAStepChoiceTableViewCell {
+                choiceCell.choiceValueLabel.text = tableItem?.choice?.choiceText
+                choiceCell.isSelected = tableItem!.selected
+            }
+        }
+        
+        return cell!
+    }
+    
+    // MARK: UITableView Delegate
+    
+    open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+        let tableItem = tableData!.tableItem(at: indexPath)
+        let answerFormat = tableItem?.formItem?.answerFormat?.implied()
+        let type = answerFormat?.questionType
+        
+        if type == .decimal || type == .integer || type == .text {
+            
+            // need to get our cell and tell its textField to become first responder
+            if let customCell = tableView.cellForRow(at: indexPath) as? SBAStepTextFieldTableViewCell {
+                customCell.textField.becomeFirstResponder()
+            }
+            
+            tableView.deselectRow(at: indexPath, animated: true)
+            
+        }
+        else {
+            
+            tableData!.selectAnswer(selected: true, at: indexPath)
+            tableView.reloadSections(IndexSet(integer: indexPath.section), with: .none)
+            
+            // Dismiss other textField's keyboard
+            tableView.endEditing(false)
+        }
+    }
+    
+    open func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        // subclass
+    }
+    
+    open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableViewAutomaticDimension
+    }
+    
+    // MARK: UITextField delegate
+    
+    public func textFieldDidBeginEditing(_ textField: UITextField) {
+        
+        if let customField = textField as? SBAStepTextField {
+            // need to scroll our tableView to the appropriate indexPath. We save our scrollOffset
+            // so we can scroll back when user is done editing
+            
+            savedVerticalScrollOffet = tableView!.contentOffset.y
+            tableView?.scrollToRow(at: customField.indexPath!, at: .bottom, animated: true)
+        }
+    }
+    
+    public func textFieldDidEndEditing(_ textField: UITextField) {
+        
+        // scroll back to our saved offset
+        tableView?.setContentOffset(CGPoint(x: 0.0, y: savedVerticalScrollOffet), animated: true)
+    }
+    
+    
+    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        
+        let textFieldText: NSString = (textField.text ?? "") as NSString
+        let textAfterUpdate = textFieldText.replacingCharacters(in: range, with: string)
+        
+        if let customTextField = textField as? SBAStepTextField {
+            if let itemGroup = tableData!.itemGroup(at: customTextField.indexPath!) {
+                
+                var answer = ORKNullAnswerValue()
+                
+                // need to determine if we need a string or a number
+                var returnValue = true
+                if let numericAnswerFormat = itemGroup.formItem.answerFormat as? ORKNumericAnswerFormat {
+                    
+                    let sanitziedText = numericAnswerFormat.sanitizedTextFieldText(textAfterUpdate, decimalSeparator: numberFormatter.decimalSeparator)
+                    textField.text = sanitziedText
+                    
+                    if sanitziedText!.characters.count > 0 {
+                        let answerNumber = NSDecimalNumber(string: sanitziedText, locale: Locale.current)
+                        if numericAnswerFormat.isAnswerValid(answerNumber) {
+                            answer = answerNumber
+                        }
+                    }
+                    
+                    // return false since we're manually updating the text field with the sanitized text
+                    returnValue = false
+                }
+                else {
+                    
+                    if itemGroup.formItem.answerFormat!.isAnswerValid(textAfterUpdate) {
+                        answer = textAfterUpdate
+                    }
+                }
+                
+                tableData!.saveAnswer(answer as AnyObject, at: customTextField.indexPath!)
+                
+                // need to update enabled state of next button in the textFields inputAccessoryView,
+                // which is a SBAStepNavigationView
+                
+                if let navView = textField.inputAccessoryView as? SBAStepNavigationView {
+                    navView.nextButton.isEnabled = tableData!.allAnswersValid()
+                }
+                return returnValue
+            }
+        }
+        
+        return true
+    }
+    
+    // MARK: UIScrollView delegate
+    
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        updateShadows()
+    }
+    
+    open func updateShadows() {
+        guard let navigationView = navigationView else { return }
+        let maxY = tableView!.contentSize.height + tableView!.contentInset.top - (tableView!.bounds.size.height - navigationView.bounds.size.height)
+        navigationView.shouldShowShadow = tableView!.contentOffset.y < maxY
+    }
+
+    
+    // MARK: KeyboardNotification delegate
+    
+    func keyboardNotification(notification: NSNotification) {
+        
+        if let userInfo = notification.userInfo {
+            let endFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+            let duration:TimeInterval = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0
+            let animationCurveRawNSN = userInfo[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber
+            let animationCurveRaw = animationCurveRawNSN?.uintValue ?? UIViewAnimationOptions.curveEaseInOut.rawValue
+            let animationCurve:UIViewAnimationOptions = UIViewAnimationOptions(rawValue: animationCurveRaw)
+            if (endFrame?.origin.y)! >= UIScreen.main.bounds.size.height {
+                
+                // set the tableView bottom inset to default
+                var inset = tableView!.contentInset
+                inset.bottom = tableViewInsetBottom
+                tableView?.contentInset = inset
+                
+            } else {
+                
+                // change tableView contentInset bottom to be equal to the height of the keyboard plue
+                // our constant for the bottom margin
+                
+                var contentInset = tableView?.contentInset
+                contentInset!.bottom = endFrame!.size.height + constants().mainViewBottomMargin
+                tableView!.contentInset = contentInset!
+            }
+            UIView.animate(withDuration: duration,
+                           delay: TimeInterval(0),
+                           options: animationCurve,
+                           animations: { self.view.layoutIfNeeded() },
+                           completion: nil)
+        }
+    }
+    
+    // MARK: SBAGenericStepDataSource delegate
+    
+    public func answersDidChange() {
+        
+        // update enabled state of next button
+        navigationView?.nextButton.isEnabled = tableData!.allAnswersValid()
+    }
+}
+
+
+public extension CGFloat {
+    
+    /**
+     Occasionally we do want UI elements to be a little bigger or wider on bigger screens,
+     such as with label widths. This can be used to increase values based on screen size. It
+     uses the small screen (320 wide) as a baseline. This is a much simpler alternative to
+     defining a matrix with screen sizes and constants and achieves much the same result
+     */
+    func proportionalToScreenWidth() -> CGFloat {
+        let baselineWidth = CGFloat(320.0)
+        return UIScreen.main.bounds.size.width / baselineWidth * self
+    }
+}
+
+
+public extension UIImage {
+    
+    /**
+     Re-color an image.
+     */
+    
+    func applyColor(_ color: UIColor) -> UIImage {
+        UIGraphicsBeginImageContextWithOptions(self.size, false, UIScreen.main.scale)
+        let context = UIGraphicsGetCurrentContext()
+        
+        color.setFill()
+        
+        context!.translateBy(x: 0, y: self.size.height)
+        context!.scaleBy(x: 1.0, y: -1.0)
+        
+        context!.setBlendMode(CGBlendMode.colorBurn)
+        let rect = CGRect(x: 0.0, y: 0.0, width: self.size.width, height: self.size.height)
+        context!.draw(self.cgImage!, in: rect)
+        
+        
+        context!.setBlendMode(CGBlendMode.sourceIn)
+        context!.addRect(rect)
+        context!.drawPath(using: CGPathDrawingMode.fill)
+        
+        let coloredImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return coloredImage!
+    }
+}
+
+class SBAGenericStepUIConfig {
+    
+    /**
+     Defines whether or not a drop shadow is shown below the top edge of the navigation view. The shadow
+     is only shown if content is underlapping the navigation view.
+     */
+    class func shouldShowNavigationViewShadow() -> Bool { return true }
+    
+    /**
+     Defines whether or not the navigation view is always pinned to the bottom of the screen, with content
+     scrolling underneath it, or it's embedded in the footerView of the tableView, in which case it
+     scrolls with the content.
+     */
+    class func shouldUseStickyNavigationView() -> Bool { return true }
+    
+    /**
+     Defines if the progress view, which shows the number of steps completed in a multi-step task,
+     should be shown at the top of the screen underneath the navigation bar.
+     */
+    class func shouldShowProgressView() -> Bool { return true }
+    
+    /**
+     Defines which back button position should be used.
+     */
+    class func backButtonPosition() -> backButtonPosition { return .navigationBar }
+}
+
+/**
+ Defines possible positions of back button for step navigation.
+ */
+public enum backButtonPosition {
+    
+    /**
+     Places back button in the navigation bar.
+     */
+    case navigationBar
+    
+    /**
+     Places back button in the navigation view, which is either pinned to the bottom of the screen
+     or embedded in the tableView.footerView.
+     */
+    case navigationView
+}
+

--- a/ResearchUXFactory/SBANavigationFormStep.swift
+++ b/ResearchUXFactory/SBANavigationFormStep.swift
@@ -90,4 +90,8 @@ open class SBANavigationFormStep: ORKFormStep, SBASurveyNavigationStep {
     override open var hash: Int {
         return super.hash ^ sharedHash()
     }
+    
+    override open func stepViewControllerClass() -> AnyClass {
+        return SBAGenericStepViewController.classForCoder()
+    }
 }

--- a/ResearchUXFactory/SBARoundedButton.swift
+++ b/ResearchUXFactory/SBARoundedButton.swift
@@ -1,0 +1,147 @@
+//
+//  SBARoundedButton.swift
+//  elevateMS
+//
+//  Created by Michael L DePhillips on 4/5/17.
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+public let SBARoundedButtonDefaultHeight: CGFloat = 52.0
+public let SBARoundedButtonDefaultCornerRadius: CGFloat = SBARoundedButtonDefaultHeight / 2
+
+@IBDesignable open class SBARoundedButton : UIButton, ORKButton {
+    
+    @IBInspectable open var corners: CGFloat = CGFloat(5) {
+        didSet {
+            refreshView()
+            setNeedsDisplay()
+        }
+    }
+
+    @IBInspectable open var shadowColor: UIColor = UIColor.roundedButtonShadowDark {
+        didSet {
+            refreshView()
+            setNeedsDisplay()
+        }
+    }
+    
+    override open var isEnabled: Bool {
+        didSet {
+            // show as disabled by lowering opacity unless alpha is used to set hidden
+            guard alpha > 0.1 else { return }
+            self.alpha = isEnabled ? CGFloat(1) : CGFloat(0.3)
+        }
+    }
+    
+    public var isInTransition: Bool = false
+    
+    open var titleFont: UIFont? {
+        didSet {
+            guard let font = titleFont else { return }
+            titleLabel?.font = font
+        }
+    }
+    
+    open var titleColor: UIColor? {
+        didSet {
+            setTitleColor(titleColor, for: .normal)
+        }
+    }
+    
+    public required init() {
+        super.init(frame: CGRect(x: 0, y: 0, width: 250, height: 51))
+        
+        // setup colors
+        self.backgroundColor = UIColor.roundedButtonBackgroundDark
+        self.shadowColor = UIColor.roundedButtonShadowDark
+        self.corners = SBARoundedButtonDefaultCornerRadius
+        
+        // setup text
+        self.titleColor = UIColor.roundedButtonTextLight
+        setTitleColor(titleColor, for: .normal)
+        
+        self.titleFont = UIFont.roundedButtonTitle
+
+        commonInit()
+    }
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        refreshView()
+    }
+    
+    open func commonInit() {
+        refreshView()
+    }
+    
+    func refreshView() {
+        guard self.alpha > 0.9 else {
+            layer.shadowOpacity = 0
+            return
+        }
+        
+        layer.cornerRadius = corners
+        
+        // Draw bottom button shadow
+        let shadowRadius = corners * 1.2
+        let shadowHeight = CGFloat(3)
+        
+        // Make sure the shadow shows up outside the view's bounds
+        clipsToBounds = false
+        layer.masksToBounds = false
+        
+        layer.shadowColor = shadowColor.cgColor
+        layer.shadowOffset = CGSize(width: 0.0, height: shadowHeight)
+        layer.shadowOpacity = 1.0
+        layer.shadowRadius = 0.0 // this is actually blur radius
+        // User this as the shadow path, since it has a larger corner radius
+        // than the default layer's corner radius
+        let shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: shadowRadius)
+        layer.shadowPath = shadowPath.cgPath
+    }
+    
+    override open func prepareForInterfaceBuilder() {
+        super.prepareForInterfaceBuilder()
+        commonInit()
+        setNeedsDisplay()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+}

--- a/ResearchUXFactory/SBAShadowGradient.swift
+++ b/ResearchUXFactory/SBAShadowGradient.swift
@@ -1,0 +1,112 @@
+//
+//  SBAShadowGradient.swift
+//  BridgeAppSDK
+//
+//  Created by Michael L DePhillips on 4/8/17.
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+@IBDesignable open class SBAShadowGradient : UIView {
+    
+    /**
+     * The color of the shadow that is drawn as the background of this
+     */
+    @IBInspectable var shadowColor : UIColor = UIColor.black {
+        didSet {
+            commonInit()
+        }
+    }
+    
+    /**
+     * The alpha value (0.0 to 1.0) that the bototm part of the gradient will be at
+     */
+    @IBInspectable var bottomAlpha : CGFloat = CGFloat(0.25) {
+        didSet {
+            commonInit()
+        }
+    }
+    
+    /**
+     * The alpha value (0.0 to 1.0) that the top part of the gradient will be at
+     */
+    @IBInspectable var topAlpha : CGFloat = CGFloat(0.0) {
+        didSet {
+            commonInit()
+        }
+    }
+    
+    let gradientLayer = CAGradientLayer()
+    
+    public init() {
+        super.init(frame: CGRect.zero)
+        commonInit()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    override open func prepareForInterfaceBuilder() {
+        super.prepareForInterfaceBuilder()
+        commonInit()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = self.bounds
+    }
+    
+    func commonInit() {
+        backgroundColor = UIColor.clear
+        gradientLayer.frame = self.bounds
+        
+        let bottomColor = shadowColor.withAlphaComponent(bottomAlpha).cgColor
+        let topColor = shadowColor.withAlphaComponent(topAlpha).cgColor
+        gradientLayer.colors = [topColor, bottomColor]
+        gradientLayer.locations = [0.0, 1.0]
+        
+        if layer.sublayers?.count ?? 0 == 0 {
+            layer.addSublayer(gradientLayer)
+        }
+    }
+    
+    override open func layoutSublayers(of layer: CALayer) {
+        super.layoutSublayers(of: layer)
+        gradientLayer.frame = self.bounds
+    }
+}

--- a/ResearchUXFactory/SBAStepChoiceTableViewCell.swift
+++ b/ResearchUXFactory/SBAStepChoiceTableViewCell.swift
@@ -1,0 +1,235 @@
+//
+//  SBAStepChoiceTableViewCell.swift
+//  ResearchUXFactory
+//
+//  Created by Josh Bruhin on 5/30/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+// MARK: Choice Cell
+
+class SBAStepChoiceTableViewCell: UITableViewCell {
+    
+    private let kShadowHeight: CGFloat = 5.0
+    private let kSideMargin = CGFloat(20.0).proportionalToScreenWidth()
+    private let kVertMargin: CGFloat = 10.0
+    private let kMinHeight: CGFloat = 75.0
+
+    var choiceValueLabel = UILabel()
+    
+    var shadowAlpha: CGFloat {
+        return isSelected ? 0.2 : 0.05
+    }
+    
+    var bgColor: UIColor {
+        return isSelected ? UIColor.choiceCellBackgroundHighlighted : UIColor.choiceCellBackground
+    }
+    
+    var labelColor: UIColor {
+        return isSelected ? UIColor.choiceCellLabelHighlighted : UIColor.choiceCellLabel
+    }
+    
+    open let shadowView: UIView = {
+        let rule = UIView()
+        rule.backgroundColor = UIColor.black
+        return rule
+    }()
+    
+    override var isSelected: Bool {
+        didSet {
+            backgroundColor = bgColor
+            choiceValueLabel.textColor = labelColor
+            shadowView.alpha = shadowAlpha
+        }
+    }
+    
+    
+    public override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        commonInit()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        commonInit()
+    }
+    
+    func commonInit() {
+        
+        self.selectionStyle = .none
+        
+        contentView.addSubview(choiceValueLabel)
+        contentView.addSubview(shadowView)
+        
+        choiceValueLabel.translatesAutoresizingMaskIntoConstraints = false
+        shadowView.translatesAutoresizingMaskIntoConstraints = false
+        
+        choiceValueLabel.preferredMaxLayoutWidth = UIScreen.main.bounds.size.width - (kSideMargin * 2)
+        
+        choiceValueLabel.numberOfLines = 0
+        choiceValueLabel.font = UIFont.choiceCellLabel
+        choiceValueLabel.textColor = labelColor
+        choiceValueLabel.textAlignment = .left
+        
+        setNeedsUpdateConstraints()
+    }
+    
+    override func updateConstraints() {
+        
+        NSLayoutConstraint.deactivate(self.constraints)
+        
+        choiceValueLabel.alignToSuperview([.leading, .trailing], padding: kSideMargin)
+        choiceValueLabel.alignToSuperview([.top], padding: kVertMargin)
+        
+        shadowView.makeHeight(.equal, kShadowHeight)
+        shadowView.alignToSuperview([.leading, .trailing, .bottom], padding: 0.0)
+        shadowView.alignBelow(view: choiceValueLabel, padding: kVertMargin)
+        
+        contentView.makeHeight(.greaterThanOrEqual, kMinHeight)
+
+        super.updateConstraints()
+    }
+}
+
+// MARK: TextField Cell
+
+open class SBAStepTextFieldTableViewCell: UITableViewCell {
+    
+    private let kVerticalMargin: CGFloat = 10.0
+    private let kVerticalPadding: CGFloat = 7.0
+    private let kSideMargin = CGFloat(25.0).proportionalToScreenWidth()
+    private let kTextFieldWidth: CGFloat = 150.0
+    
+    public var textField: UITextField!
+    open var ruleView: UIView!
+    
+    /**
+     Layout constants. Subclasses can override to customize; otherwise the default private
+     constants are used.
+     */
+    open func constants() -> (
+        verticalMargin: CGFloat,
+        verticalPadding: CGFloat,
+        sideMargin: CGFloat,
+        textFieldWidth: CGFloat)
+    {
+        return (kVerticalMargin,
+                kVerticalPadding,
+                kSideMargin,
+                kTextFieldWidth)
+    }
+    
+    /**
+     Create all the view elements. Subclasses can override to provide custom instances.
+     */
+    open func initializeViews() {
+        textField = SBAStepTextField()
+        ruleView = UIView()
+    }
+    
+    /**
+     Define the subView properties.
+     */
+    open func setupViews() {
+        
+        textField.font = UIFont.textFieldCellText
+        textField.textColor = UIColor.textFieldCellFieldText
+        textField.textAlignment = .center
+        
+        ruleView.backgroundColor = UIColor.textFieldCellFieldBorder
+    }
+    
+    public override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        commonInit()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    override open func awakeFromNib() {
+        super.awakeFromNib()
+        commonInit()
+    }
+    
+    func commonInit() {
+        
+        initializeViews()
+        setupViews()
+        
+        contentView.addSubview(textField)
+        contentView.addSubview(ruleView)
+        
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        ruleView.translatesAutoresizingMaskIntoConstraints = false
+        
+        setNeedsUpdateConstraints()
+    }
+    
+    override open func updateConstraints() {
+        
+        NSLayoutConstraint.deactivate(self.constraints)
+        
+        // if we have a defined textField width, we use that and center the text field and ruleView horizontally.
+        // Otherwise, we pin left and right edges to the superview with some side margin
+        
+        if constants().textFieldWidth > 0 {
+            
+            textField.makeWidth(.equal, constants().textFieldWidth)
+            textField.alignCenterHorizontal(padding: 0.0)
+        } else {
+
+            textField.alignToSuperview([.leading, .trailing], padding: constants().sideMargin)
+        }
+
+        textField.alignToSuperview([.top], padding: constants().verticalMargin)
+        
+        ruleView.alignBelow(view: textField, padding: constants().verticalPadding)
+        ruleView.makeHeight(.equal, 1.0)
+        
+        // align left and right edges of ruleView to the textField
+        ruleView.align([.leading, .trailing], .equal, to: textField, [.leading, .trailing], padding: 0.0)
+        
+        super.updateConstraints()
+    }
+}
+
+class SBAStepTextField: UITextField {
+    var indexPath: IndexPath?
+}
+

--- a/ResearchUXFactory/SBAStepHeaderView.swift
+++ b/ResearchUXFactory/SBAStepHeaderView.swift
@@ -1,0 +1,331 @@
+//
+//  SBAStepHeaderView.swift
+//  ResearchUXFactory
+//
+//  Created by Josh Bruhin on 5/25/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+/**
+ A custom UIView to be included in an SBAGenericStepViewController. It optionally contains several subViews
+ and displays them in this order, from top to bottom of the view:
+ 
+ 1) progressView: SBAStepProgressView - show progress thru the current flow
+ 2) imageView: UIImageView - shows an image associated with the current step
+ 3) headerLabel: UILabel - generally the Title of the current step
+ 4) detailsLabel: UILabel - generally the Text of the current step
+ 5) customView: UIView - any custom view provided by the SBAGenericStepViewController
+ 6) learnMoreButton: UIButton - a button to call the learnMoreAction
+ 7) promptLabel: UILabel - a label intended to prompt the user to enter data or make a selection
+ 
+ Several public properties are provided to configure the view, such has hiding or showing the learnMoreButton
+ or progressView, and providing a minimumHeight or customView.
+ 
+ To customize the view elements, subclasses should override the initializeViews() method. This will allow
+ the use of any custom element (of the appropriate type) to be used instead of the default instances.
+ */
+
+open class SBAStepHeaderView: UIView {
+    
+    private let kTopMargin: CGFloat = CGFloat(30.0).proportionalToScreenWidth()
+    private let kSideMargin: CGFloat = CGFloat(30.0).proportionalToScreenWidth()
+    private let kVerticalSpacing: CGFloat = CGFloat(20.0).proportionalToScreenWidth()
+    private let kBottomMargin: CGFloat = 10.0
+    private let kImageViewHeight: CGFloat = CGFloat(100.0).proportionalToScreenWidth()
+    private let kLearnMoreButtonHeight: CGFloat = 30.0
+    private let kLabelMaxLayoutWidth: CGFloat = {
+        return CGFloat(UIScreen.main.bounds.size.width - (2 * CGFloat(30.0).proportionalToScreenWidth()))
+    }()
+    
+    /**
+     Causes the progress view to be shown or hidden. Default is the value from UI config.
+     */
+    open var shouldShowProgress = SBAGenericStepUIConfig.shouldShowProgressView() {
+        didSet {
+            progressView.isHidden = !shouldShowProgress
+            setNeedsUpdateConstraints()
+        }
+    }
+    
+    /**
+     Causes the learn more button to be shown or hidden.
+     */
+    open var shouldShowLearnMore: Bool = false {
+        didSet {
+            learnMoreButton.isHidden = !shouldShowLearnMore
+            setNeedsUpdateConstraints()
+        }
+    }
+    
+    /**
+     Causes an image to be shown or hidden. It will assign the provided image (or nil) to the
+     imageView. The imageView will be hidden automatically if the imageView.image is nil.
+     */
+    open var image: UIImage? {
+        didSet {
+            imageView.image = image
+            setNeedsUpdateConstraints()
+        }
+    }
+    
+    /**
+     An optional view that can be included. It is shown directly below the detailsLabel
+     and above the learnMoreButton. This view can be provided by subclasses in the initializeViews()
+     method or assigned later.
+     */
+    open var customView: UIView? {
+        didSet {
+            if customView != nil {
+                self.addSubview(customView!)
+                setNeedsUpdateConstraints()
+            }
+        }
+    }
+    
+    /**
+     Causes the main view to be resized to this minimum height, if necessary. The extra needed height
+     is added to and divided equally between the top margin and bottom margin of the main view.
+     */
+    open var minumumHeight: CGFloat = 0.0 {
+        didSet {
+            setNeedsUpdateConstraints()
+        }
+    }
+    
+    open var progressView: SBAStepProgressView!
+    open var learnMoreButton: UIButton!
+    
+    open var headerLabel: UILabel!
+    open var detailsLabel: UILabel!
+    open var promptLabel: UILabel!
+    open var imageView: UIImageView!
+    
+    
+    /**
+     Layout constants. Subclasses can override to customize; otherwise the default private
+     constants are used.
+     */
+    open func constants() -> (
+        topMargin: CGFloat,
+        bottomMargin: CGFloat,
+        sideMargin: CGFloat,
+        verticalSpacing: CGFloat,
+        imageViewHeight: CGFloat,
+        labelMaxLayoutWidth: CGFloat)
+    {
+        return (kTopMargin,
+                kBottomMargin,
+                kSideMargin,
+                kVerticalSpacing,
+                kImageViewHeight,
+                kLabelMaxLayoutWidth)
+    }
+    
+    /**
+     Create all the view elements. Subclasses can override to provide custom instances. A customView
+     can optionally be created here by the subclass.
+     */
+    open func initializeViews() {
+        
+        progressView = SBAStepProgressView()
+        learnMoreButton = SBAUnderlinedButton()
+        
+        headerLabel = UILabel()
+        detailsLabel = UILabel()
+        promptLabel = UILabel()
+        imageView = UIImageView()
+        
+        // customView used by subclass, not initialized here
+    }
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    fileprivate func commonInit() {
+        
+        initializeViews()
+        
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        headerLabel.translatesAutoresizingMaskIntoConstraints = false
+        detailsLabel.translatesAutoresizingMaskIntoConstraints = false
+        promptLabel.translatesAutoresizingMaskIntoConstraints = false
+        learnMoreButton.translatesAutoresizingMaskIntoConstraints = false
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        if shouldShowProgress {
+            // add progress view
+            self.addSubview(progressView)
+        }
+        
+        
+        // add imageView
+        imageView.contentMode = .scaleAspectFit
+        self.addSubview(imageView)
+        
+        
+        // add labels
+        self.addSubview(headerLabel)
+        self.addSubview(detailsLabel)
+        self.addSubview(promptLabel)
+        
+        headerLabel.accessibilityTraits = UIAccessibilityTraitHeader
+        detailsLabel.accessibilityTraits = UIAccessibilityTraitSummaryElement
+        
+        headerLabel.numberOfLines = 0
+        detailsLabel.numberOfLines = 0
+        promptLabel.numberOfLines = 0
+        
+        headerLabel.font = UIFont.headerViewHeaderLabel
+        detailsLabel.font = UIFont.headerViewDetailsLabel
+        promptLabel.font = UIFont.headerViewPromptLabel
+        
+        headerLabel.textColor = UIColor.headerViewHeaderLabel
+        detailsLabel.textColor = UIColor.headerViewDetailsLabel
+        promptLabel.textColor = UIColor.headerViewPromptLabel
+        
+        headerLabel.textAlignment = .center
+        detailsLabel.textAlignment = .center
+        promptLabel.textAlignment = .center
+        
+        headerLabel.preferredMaxLayoutWidth = constants().labelMaxLayoutWidth
+        detailsLabel.preferredMaxLayoutWidth = constants().labelMaxLayoutWidth
+        promptLabel.preferredMaxLayoutWidth = constants().labelMaxLayoutWidth
+        
+        // add learn more button
+        self.addSubview(learnMoreButton)
+        
+        // customView, if any
+        if let customView = customView {
+            self.addSubview(customView)
+        }
+        
+        setNeedsUpdateConstraints()
+    }
+    
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        headerLabel.preferredMaxLayoutWidth = headerLabel.frame.size.width
+        detailsLabel.preferredMaxLayoutWidth = detailsLabel.frame.size.width
+        
+        layoutIfNeeded()
+    }
+    
+    open override func updateConstraints() {
+        
+        NSLayoutConstraint.deactivate(self.constraints)
+        
+        var gap = constants().topMargin
+        
+        if shouldShowProgress {
+            // progress view
+            progressView.alignToSuperview([.leading, .trailing, .top], padding: 0.0)
+            
+            // image view
+            imageView.alignBelow(view: progressView, padding: gap)
+            
+        } else {
+            
+            // image view
+            imageView.alignToSuperview([.top], padding: gap)
+        }
+        
+        imageView.alignCenterHorizontal(padding: 0.0)
+        imageView.makeHeight(.equal, (image == nil ? 0.0 : constants().imageViewHeight))
+        
+        gap = image != nil ? constants().verticalSpacing : 0.0
+        
+        // header label
+        headerLabel.alignBelow(view: imageView, padding: gap)
+        headerLabel.alignToSuperview([.leading, .trailing], padding: constants().sideMargin)
+        headerLabel.makeHeight(.greaterThanOrEqual, 0.0)
+        
+        gap = headerLabel.text != nil ? constants().verticalSpacing : 0.0
+        
+        // details label
+        detailsLabel.alignBelow(view: headerLabel, padding: gap)
+        detailsLabel.alignToSuperview([.leading, .trailing], padding: constants().sideMargin)
+        detailsLabel.makeHeight(.greaterThanOrEqual, 0.0)
+        
+        gap = detailsLabel.text != nil ? constants().verticalSpacing : 0.0
+        
+        if let customView = customView {
+            // we align left and right to superview and top to view above
+            customView.translatesAutoresizingMaskIntoConstraints = false
+            customView.alignBelow(view: detailsLabel, padding: gap)
+            customView.alignToSuperview([.leading, .trailing], padding: 0.0)
+            
+            // we assume the height constraint has been set
+            // TODO: Josh Bruhin, 6/12/17 - check for or enforce this
+            
+            gap = constants().verticalSpacing
+        }
+        
+        // learn more button
+        let viewAbove = customView != nil ? customView : detailsLabel
+        learnMoreButton.alignBelow(view: viewAbove!, padding: gap)
+        learnMoreButton.alignCenterHorizontal(padding: 0.0)
+        learnMoreButton.makeHeight(.equal, (shouldShowLearnMore ? kLearnMoreButtonHeight : 0.0))
+        
+        gap = shouldShowLearnMore ? constants().verticalSpacing : 0.0
+        
+        // prompt label
+        promptLabel.alignBelow(view: learnMoreButton, padding: gap)
+        promptLabel.alignCenterHorizontal(padding: 0.0)
+        promptLabel.makeHeight(.greaterThanOrEqual, 0.0)
+        
+        gap = constants().bottomMargin
+        
+        promptLabel.alignToSuperview([.bottom], padding: gap)
+        
+        // check our minimum height
+        let height = self.systemLayoutSizeFitting(UILayoutFittingCompressedSize).height
+        if height < minumumHeight {
+            
+            // adjust our top and bottom margins
+            let topConstraint = imageView.constraint(for: .top, relation: .equal)
+            let bottomConstraint = promptLabel.constraint(for: .bottom, relation: .equal)
+            
+            let marginIncrease = (minumumHeight - height) / 2
+            topConstraint?.constant += marginIncrease
+            bottomConstraint?.constant -= marginIncrease
+        }
+        
+        super.updateConstraints()
+    }
+}

--- a/ResearchUXFactory/SBAStepNavigationView.swift
+++ b/ResearchUXFactory/SBAStepNavigationView.swift
@@ -1,0 +1,180 @@
+//
+//  SBAStepNavigationView.swift
+//  ResearchUXFactory
+//
+//  Created by Josh Bruhin on 5/23/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+/**
+ A custom UIView to be included in an SBAGenericStepViewController. It contains a Next button,
+ Previous button, and shadowView. The ViewController is responsible for assigning targets and
+ actions to the buttons.
+ 
+ To customize the view elements, subclasses should override the initializeViews() method. This will allow
+ the use of any custom element (of the appropriate type) to be used instead of the default instances.
+ */
+
+open class SBAStepNavigationView: UIView {
+    
+    private let kTopMargin: CGFloat = 16.0
+    private let kBottomMargin: CGFloat = 20.0
+    private let kSideMargin: CGFloat = CGFloat(25.0).proportionalToScreenWidth()
+    private let kButtonWidth: CGFloat = CGFloat(120.0).proportionalToScreenWidth()
+    private let kShadowHeight: CGFloat = 5.0
+    private let showPreviousButton = SBAGenericStepUIConfig.backButtonPosition() == .navigationView
+    
+    
+    open var previousButton: UIButton!
+    open var nextButton: UIButton!
+    open var shadowView: UIView!
+    
+    open var buttonCornerRadius = SBARoundedButtonDefaultCornerRadius
+    
+    /**
+     Causes the drop shadow at the top of the view to be shown or hidden.
+     If the value in app configuration is false, that overrides any attempt to set to true
+     */
+    private var _shouldShowShadow = false
+    open var shouldShowShadow: Bool {
+        set {
+            let shadowEnabled = SBAGenericStepUIConfig.shouldShowNavigationViewShadow()
+            _shouldShowShadow = shadowEnabled && newValue
+            self.shadowView.isHidden = !_shouldShowShadow
+            self.clipsToBounds = !_shouldShowShadow
+        }
+        get {
+            return _shouldShowShadow
+        }
+    }
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    /**
+     Layout constants. Subclasses can override to customize; otherwise the default private
+     constants are used.
+     */
+    open func constants() -> (
+        topMargin: CGFloat,
+        bottomMargin: CGFloat,
+        sideMargin: CGFloat,
+        buttonWidth: CGFloat,
+        shadowHeight: CGFloat)
+    {
+        return (kTopMargin,
+                kBottomMargin,
+                kSideMargin,
+                kButtonWidth,
+                kShadowHeight)
+    }
+    
+    /**
+     Create all the view elements. Subclasses can override to provide custom instances.
+     */
+    open func initializeViews() {
+        previousButton = SBARoundedButton()
+        nextButton = SBARoundedButton()
+        shadowView = SBAShadowGradient()
+    }
+    
+    
+    fileprivate func commonInit() {
+        
+        initializeViews()
+        
+        // TODO: Josh Bruhin, 6/12/17 - localize strings and get label strings properly
+        nextButton.setTitle("Next", for: .normal)
+        previousButton.setTitle("Previous", for: .normal)
+        
+        if let nextRounded = nextButton as? SBARoundedButton {
+            nextRounded.corners = buttonCornerRadius
+        }
+        if let prevRounded = previousButton as? SBARoundedButton {
+            prevRounded.corners = buttonCornerRadius
+        }
+        
+        previousButton.translatesAutoresizingMaskIntoConstraints = false
+        nextButton.translatesAutoresizingMaskIntoConstraints = false
+        shadowView.translatesAutoresizingMaskIntoConstraints = false
+        
+        // add previous and next buttons
+        if showPreviousButton {
+            self.addSubview(previousButton)
+        }
+        self.addSubview(nextButton)
+        self.addSubview(shadowView)
+        
+        shadowView.isHidden = !shouldShowShadow
+        
+        setNeedsUpdateConstraints()
+    }
+    
+    open override func updateConstraints() {
+        
+        NSLayoutConstraint.deactivate(self.constraints)
+        
+        if showPreviousButton {
+
+            previousButton.makeWidth(.equal, constants().buttonWidth)
+            previousButton.makeHeight(.equal, SBARoundedButtonDefaultHeight)
+            
+            previousButton.alignToSuperview([.leading], padding: constants().sideMargin)
+            previousButton.alignToSuperview([.top], padding: constants().topMargin)
+            previousButton.alignToSuperview([.bottom], padding: constants().bottomMargin)
+            
+            // if we have a previousButton, then define width or nextButton
+            nextButton.makeWidth(.equal, constants().buttonWidth)
+            
+        } else {
+            // if we don't have previousButton, align left edge of nextButton to superview left
+            nextButton.alignToSuperview([.leading], padding: constants().sideMargin)
+        }
+        
+        nextButton.makeHeight(.equal, SBARoundedButtonDefaultHeight)
+        nextButton.alignToSuperview([.trailing], padding: constants().sideMargin)
+        nextButton.alignToSuperview([.top], padding: constants().topMargin)
+        nextButton.alignToSuperview([.bottom], padding: constants().bottomMargin)
+        
+        shadowView.alignToSuperview([.leading, .trailing], padding: 0.0)
+        shadowView.alignToSuperview([.top], padding:  -1 * constants().shadowHeight)
+        shadowView.makeHeight(.equal, constants().shadowHeight)
+        
+        super.updateConstraints()
+    }
+}

--- a/ResearchUXFactory/SBAStepProgressView.swift
+++ b/ResearchUXFactory/SBAStepProgressView.swift
@@ -1,0 +1,156 @@
+//
+//  SBAStepProgressView.swift
+//  ResearchUXFactory
+//
+//  Created by Josh Bruhin on 5/25/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+/**
+ A UIView subclass that displays a progress bar going from left to right and a label
+ that is positioned under the progress bar to display current step and number of steps.
+ Views should set currentStep and totalSteps to cause progress to be displayed.
+ */
+
+open class SBAStepProgressView: UIView {
+    
+    /**
+     The current step in the current flow
+     */
+    public var currentStep: Int = 0 { didSet { progressChanged() } }
+    
+    /**
+     The total number of steps in the current flow
+     */
+    public var totalSteps: Int = 0 { didSet { progressChanged() } }
+    
+    
+    private let kProgressLineHeight: CGFloat = 8.0
+    
+    private var progress: CGFloat {
+        if totalSteps > 0 {
+            return CGFloat(currentStep) / CGFloat(totalSteps)
+        } else {
+            return 0.0
+        }
+    }
+    
+    // MARK: View elements
+    
+    var progressView = UIView()
+    var backgroundView = UIView()
+    var stepCountLabel = UILabel()
+    
+    
+    // MARK: Available for override
+    
+    /**
+     The height of the actual progress bar
+     */
+    open func progressLineHeight() -> CGFloat {
+        return currentStep > 0 && totalSteps > 0 ? kProgressLineHeight : 0.0
+    }
+    
+    /**
+     The text of the label that is displayed directly under the progress bar
+     */
+    open func stringForLabel() -> String? {
+        // TODO: Josh Bruhin, 6/12/17 - localize string
+        return currentStep > 0 && totalSteps > 0 ? "Step \(currentStep) of \(totalSteps)" : nil
+    }
+    
+    // MARK: Initializers
+    
+    public init() {
+        super.init(frame: CGRect.zero)
+        commonInit()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    func commonInit() {
+        
+        self.addSubview(backgroundView)
+        self.addSubview(progressView)
+        self.addSubview(stepCountLabel)
+        
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        stepCountLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        backgroundView.backgroundColor = UIColor.headerViewProgressBackground
+        progressView.backgroundColor = UIColor.headerViewProgressBar
+        
+        stepCountLabel.font = UIFont.headerViewStepCountLabel
+        stepCountLabel.numberOfLines = 1
+        stepCountLabel.textAlignment = .center
+        stepCountLabel.textColor = UIColor.headerViewStepCountLabel
+        stepCountLabel.text = stringForLabel()
+        
+        setNeedsUpdateConstraints()
+    }
+    
+    open override func updateConstraints() {
+        
+        NSLayoutConstraint.deactivate(self.constraints)
+        
+        backgroundView.alignToSuperview([.leading, .trailing, .top], padding: 0.0)
+        backgroundView.makeHeight(.equal, progressLineHeight())
+        
+        progressView.alignToSuperview([.leading, .top], padding: 0.0)
+        progressView.makeWidthEqualToSuperview(multiplier: progress)
+        progressView.makeHeight(.equal, progressLineHeight())
+        
+        stepCountLabel.alignToSuperview([.leading, .trailing], padding: 0.0)
+        stepCountLabel.alignBelow(view: progressView, padding: 5.0)
+        stepCountLabel.makeHeight(.greaterThanOrEqual, 0.0)
+        stepCountLabel.alignToSuperview([.bottomMargin], padding: 0.0)
+        
+        super.updateConstraints()
+    }
+    
+    func progressChanged() {
+        
+        if currentStep > 0 && totalSteps > 0 {
+            
+            if let widthConstraint = progressView.constraint(for: .width, relation: .equal) {
+                _ = widthConstraint.setMultiplier(multiplier: progress)
+                progressView.setNeedsLayout()
+            }
+            
+            stepCountLabel.text = stringForLabel()
+            setNeedsLayout()
+        }
+    }
+}

--- a/ResearchUXFactory/SBAUnderlinedButton.swift
+++ b/ResearchUXFactory/SBAUnderlinedButton.swift
@@ -1,0 +1,103 @@
+//
+//  SBAUnderlinedButton.swift
+//  BridgeAppSDK
+//
+//  Created by Michael L DePhillips on 4/7/17.
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+@IBDesignable open class SBAUnderlinedButton : UIButton {
+    
+    /**
+     * The color of the link button
+     */
+    @IBInspectable open var textColor : UIColor = UIColor.blueTintColor {
+        didSet {
+            refreshView()
+        }
+    }
+    
+    /**
+     * The font used for the text button
+     */
+    @IBInspectable open var textFont : UIFont = UIFont.systemFont(ofSize: 17) {
+        didSet {
+            refreshView()
+        }
+    }
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    override open func prepareForInterfaceBuilder() {
+        super.prepareForInterfaceBuilder()
+        commonInit()
+        setNeedsDisplay()
+    }
+    
+    open func commonInit() {
+        backgroundColor = UIColor.clear
+        refreshView()
+    }
+    
+    func refreshView() {
+        // Forces refresh of current title to be attributed
+        setTitle(self.currentTitle, for: .normal)
+    }
+    
+    // Force all titles to be an attributed title
+    override open func setTitle(_ title: String?, for state: UIControlState) {
+        super.setTitle(title, for: state)
+        self.setAttributedTitle(attributedString(title), for: state)
+    }
+    
+    // Create an attributed string for this class that uses the following properties
+    private func attributedString(_ title: String?) -> NSAttributedString? {
+        if let titleUnwrapped = title {
+            let attributes: [String : Any] = [
+                NSFontAttributeName : textFont,
+                NSForegroundColorAttributeName : textColor,
+                NSUnderlineStyleAttributeName : NSUnderlineStyle.styleSingle.rawValue
+            ]
+            return NSAttributedString(string: titleUnwrapped, attributes: attributes)
+        } else {
+            return nil
+        }
+    }
+}

--- a/ResearchUXFactory/SBAVisualConsentStep.swift
+++ b/ResearchUXFactory/SBAVisualConsentStep.swift
@@ -1,0 +1,62 @@
+//
+//  SBAVisualConsentStep.swift
+//  ResearchUXFactory
+//
+//  Created by Josh Bruhin on 7/6/17.
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+
+import UIKit
+
+class SBAVisualConsentStep: ORKPageStep {
+    
+    private var consentDocument: ORKConsentDocument!
+    
+    public init(identifier: String, consentDocument: ORKConsentDocument) {
+        super.init(identifier: identifier, steps: SBAVisualConsentStep.instructionSteps(for: consentDocument))
+    }
+    
+    override init(identifier: String, steps: [ORKStep]?) {
+        super.init(identifier: identifier, steps: steps)
+    }
+    
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override func stepViewControllerClass() -> AnyClass {
+        return SBAGenericPageStepViewController.classForCoder()
+    }
+    
+    static func instructionSteps(for consentDocument: ORKConsentDocument) -> Array<SBAInstructionStep> {
+        
+        var steps = Array<SBAInstructionStep>()
+        for section in consentDocument.sections! {
+            
+            // skip the 'onlyInDocument' section
+            if section.type == .onlyInDocument { continue }
+            
+            // we don't have a step identifier as these are consent scenes, so let's use the consent
+            // title as our identifier. Would prefer to use .type enum here, but most of the sections
+            // are defined with same type - custom
+            
+            guard let identifier = section.title else { continue }
+            
+            let instructionStep = SBAInstructionStep(identifier: identifier)
+            instructionStep.title = section.title
+            instructionStep.text = section.summary
+            instructionStep.image = section.image
+            
+            // if there's learn more content, add an action to the instruction step with the content
+            if let htmlContent = section.htmlContent {
+                let action = SBAURLLearnMoreAction(identifier: identifier)
+                action.learnMoreHTML = htmlContent
+                instructionStep.learnMoreAction = action
+            }
+            
+            steps.append(instructionStep)
+        }
+        
+        return steps
+    }
+}

--- a/ResearchUXFactory/SBAVisualConsentStep.swift
+++ b/ResearchUXFactory/SBAVisualConsentStep.swift
@@ -3,7 +3,33 @@
 //  ResearchUXFactory
 //
 //  Created by Josh Bruhin on 7/6/17.
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 import UIKit

--- a/ResearchUXFactory/UIColor+BridgeKeyNames.swift
+++ b/ResearchUXFactory/UIColor+BridgeKeyNames.swift
@@ -1,0 +1,161 @@
+//
+//  UIColor+BridgeKeyNames.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+extension UIColor {
+    
+    // MARK: App background - default colors
+    
+    open class var appBackgroundLight: UIColor {
+        return UIColor.white
+    }
+    
+    open class var appBackgroundDark: UIColor {
+        return UIColor.primaryTintColor ?? UIColor.magenta
+    }
+    
+    open class var appBackgroundGreen: UIColor {
+        return UIColor.greenTintColor
+    }
+    
+    
+    // MARK: App text - default colors
+    
+    open class var appTextLight: UIColor {
+        return UIColor.white
+    }
+    
+    open class var appTextDark: UIColor {
+        return UIColor(red: 65.0 / 255.0, green: 72.0 / 255.0, blue: 89.0 / 255.0, alpha: 1.0)
+    }
+    
+    open class var appTextGreen: UIColor {
+        return UIColor.white
+    }
+    
+    
+    // MARK: Underlined button - default colors
+    
+    open class var underlinedButtonTextLight: UIColor {
+        return UIColor.white
+    }
+    
+    open class var underlinedButtonTextDark: UIColor {
+        return UIColor(red: 73.0 / 255.0, green: 91.0 / 255.0, blue: 122.0 / 255.0, alpha: 1.0)
+    }
+    
+    
+    // MARK: Rounded button - default colors
+    
+    open class var roundedButtonBackgroundDark: UIColor {
+        return UIColor(red: 1.0, green: 136.0 / 255.0, blue: 117.0 / 255.0, alpha: 1.0)
+    }
+    
+    open class var roundedButtonShadowDark: UIColor {
+        return UIColor(red: 242.0 / 255.0, green: 128.0 / 255.0, blue: 111.0 / 255.0, alpha: 1.0)
+    }
+    
+    open class var roundedButtonTextLight: UIColor {
+        return UIColor.white
+    }
+    
+    open class var roundedButtonBackgroundLight: UIColor {
+        return UIColor.white
+    }
+    
+    open class var roundedButtonShadowLight: UIColor {
+        return UIColor(white: 245.0 / 255.0, alpha: 1.0)
+    }
+    
+    open class var roundedButtonTextDark: UIColor {
+        return UIColor.appBackgroundDark
+    }
+    
+    // MARK: Generic step view controller - header view
+    
+    open class var headerViewHeaderLabel: UIColor {
+        return UIColor.darkGray
+    }
+    
+    open class var headerViewDetailsLabel: UIColor {
+        return UIColor.gray
+    }
+    
+    open class var headerViewPromptLabel: UIColor {
+        return UIColor.lightGray
+    }
+    
+    open class var headerViewProgressBar: UIColor {
+        return UIColor(red: 103.0 / 255.0, green: 191.0 / 255.0, blue: 95.0 / 255.0, alpha: 1.0)
+    }
+    
+    open class var headerViewProgressBackground: UIColor {
+        return UIColor.darkGray
+    }
+
+    open class var headerViewStepCountLabel: UIColor {
+        return UIColor.darkGray
+    }
+    
+    // MARK: Generic step view controller - choice cell
+    
+    open class var choiceCellBackground: UIColor {
+        return UIColor.white
+    }
+    
+    open class var choiceCellBackgroundHighlighted: UIColor {
+        return UIColor.lightGray
+    }
+
+    open class var choiceCellLabel: UIColor {
+        return UIColor.darkGray
+    }
+    
+    open class var choiceCellLabelHighlighted: UIColor {
+        return UIColor.darkGray
+    }
+    
+    // MARK: Generic step view controller - text field cell
+    
+    open class var textFieldCellFieldText: UIColor {
+        return UIColor.darkGray
+    }
+    
+    open class var textFieldCellFieldBorder: UIColor {
+        return UIColor.darkGray
+    }
+
+}
+
+

--- a/ResearchUXFactory/UIFont+BridgeKeyNames.swift
+++ b/ResearchUXFactory/UIFont+BridgeKeyNames.swift
@@ -1,0 +1,86 @@
+//
+//  UIColor+BridgeKeyNames.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+extension UIFont {
+    
+    /*
+     * Zeplin thinks it can reference SF font by name like "SanFranciscoText-Light",
+     * but we need to convert that name to the system font with weight for it to work
+     */
+    class func sfFont(_ size : CGFloat, _ weight: CGFloat) -> UIFont! {
+        return UIFont.systemFont(ofSize: size, weight: weight)
+    }
+    
+    class func sfFontItalic(_ size : CGFloat) -> UIFont! {
+        return UIFont.italicSystemFont(ofSize: size)
+    }
+
+    // MARK: Rounded button
+    
+    open class var roundedButtonTitle: UIFont {
+        return sfFont(19.0, UIFontWeightSemibold)
+    }
+    
+    // MARK: Generic step view controller - header view labels
+
+    open class var headerViewHeaderLabel: UIFont {
+        return sfFont(23.0, UIFontWeightRegular)
+    }
+    
+    open class var headerViewDetailsLabel: UIFont {
+        return sfFont(17.0, UIFontWeightRegular)
+    }
+    
+    open class var headerViewPromptLabel: UIFont {
+        return sfFont(15.0, UIFontWeightRegular)
+    }
+
+    open class var headerViewStepCountLabel: UIFont {
+        return sfFont(14.0, UIFontWeightRegular)
+    }
+    
+    // MARK: Generic step view controller - choice cell
+
+    open class var choiceCellLabel: UIFont {
+        return sfFont(19.0, UIFontWeightSemibold)
+    }
+    
+    // MARK: Generic step view controller - text field cell
+
+    open class var textFieldCellText: UIFont {
+        return sfFont(24.0, UIFontWeightRegular)
+    }
+
+}

--- a/ResearchUXFactory/UIView+LayoutExtensions.swift
+++ b/ResearchUXFactory/UIView+LayoutExtensions.swift
@@ -119,4 +119,309 @@ extension UIView {
         
         superview.addConstraints(constraints)
     }
+    
+    
+    /**
+     A convenience method to align all edges of the view to the edges of another view. Note: this method
+     does not use the 'margin' attributes, such as .topMargin, but uses the 'edge' attributes, such as .top
+     
+     @param relation    The 'NSLayoutRelation' to apply to all constraints.
+     @param view        The 'UIView' to which the view will be aligned.
+     @param padding     The padding (or inset) to be applied to each constraint.
+     */
+    public func alignAll(_ relation: NSLayoutRelation, to view: UIView!, padding: CGFloat) {
+        let attributes: [NSLayoutAttribute] = [.leading, .top, .trailing, .bottom]
+        align(attributes, relation, to: view, attributes, padding: padding)
+    }
+
+    /**
+     A convenience method to align an array of attributes of the view to the same attributes of it's superview.
+     
+     @param attribute   The 'NSLayoutAttribute' to align to the view's superview.
+     @param padding     The padding (or inset) to be applied to the constraint.
+     */
+    public func alignToSuperview(_ attributes: [NSLayoutAttribute], padding: CGFloat) {
+        align(attributes, .equal, to: self.superview, attributes, padding: padding)
+    }
+
+    /**
+     A convenience method to align all edges of the view to the edges of its superview. Note: this method
+     does not use the 'margin' attributes, such as .topMargin, but uses the 'edge' attributes, such as .top
+     
+     @param padding     The padding (or inset) to be applied to each constraint.
+     */
+    public func alignAllToSuperview(padding: CGFloat) {
+        alignAll(.equal, to: self.superview, padding: padding)
+    }
+
+    /**
+     A convenience method to position the view below another view.
+     
+     @param view        The 'UIView' to which the view will be aligned.
+     @param padding     The padding (or inset) to be applied to the constraint.
+     */
+    public func alignBelow(view: UIView, padding: CGFloat) {
+        align([.top], .equal, to: view, [.bottom], padding: padding)
+    }
+
+    /**
+     A convenience method to position the view above another view.
+     
+     @param view        The 'UIView' to which the view will be aligned.
+     @param padding     The padding (or inset) to be applied to the constraint.
+     */
+    public func alignAbove(view: UIView, padding: CGFloat) {
+        align([.bottom], .equal, to: view, [.top], padding: padding)
+    }
+
+    /**
+     A convenience method to position the view to the left of another view.
+     
+     @param view        The 'UIView' to which the view will be aligned.
+     @param padding     The padding (or inset) to be applied to the constraint.
+     */
+    public func alignLeftOf(view: UIView, padding: CGFloat) {
+        align([.trailing], .equal, to: view, [.leading], padding: padding)
+    }
+
+    /**
+     A convenience method to position the view to the right of another view.
+     
+     @param view        The 'UIView' to which the view will be aligned.
+     @param padding     The padding (or inset) to be applied to the constraint.
+     */
+    public func alignRightOf(view: UIView, padding: CGFloat) {
+        align([.leading], .equal, to: view, [.trailing], padding: padding)
+    }
+    
+    /**
+     A convenience method to create a NSLayoutConstraint for the purpose of aligning views within
+     their 'superview'. As such, the view must have a 'superview'.
+     
+     @param attributes      An array of 'NSLayoutAttribute' to be applied to the 'firstItem' (self) in the constraints.
+     @param relation        The 'NSLayoutRelation' used for the constraint.
+     @param view            The 'UIView' that the view is being constrained to.
+     @param toAttributes    An array of 'NSLayoutAttribute' to be applied to the 'secondItem' (to View) in the constraints.
+     @param padding         The padding (or inset) to be applied to the constraints.
+     */
+    public func align(_ attributes: [NSLayoutAttribute]!, _ relation: NSLayoutRelation, to view:UIView!, _ toAttributes: [NSLayoutAttribute]!, padding: CGFloat) {
+        
+        guard let superview = self.superview else {
+            assertionFailure("Trying to set constraints without first setting superview")
+            return
+        }
+        
+        guard attributes.count > 0 else {
+            assertionFailure("'attributes' must contain at least one 'NSLayoutAttribute'")
+            return
+        }
+
+        guard attributes.count == toAttributes.count else {
+            assertionFailure("The number of 'attributes' must match the number of 'toAttributes'")
+            return
+        }
+        
+        attributes.forEach({
+            
+            let toAttribute = toAttributes[attributes.index(of: $0)!]
+            let _padding = $0 == .trailing || $0 == .bottom ? -1 * padding : padding
+            superview.addConstraint(NSLayoutConstraint(item: self,
+                                                       attribute: $0,
+                                                       relatedBy: relation,
+                                                       toItem: view,
+                                                       attribute: toAttribute,
+                                                       multiplier: 1.0,
+                                                       constant: _padding))
+
+        })
+
+
+    }
+
+    /**
+     A convenience method to center the view vertically within its 'superview'. The view must have
+     a 'superview'.
+     
+     @param padding     The padding (or offset from center) to be applied to the constraint.
+     */
+    public func allignCenterVertical(padding: CGFloat) {
+        
+        guard let superview = self.superview else {
+            assertionFailure("Trying to set constraints without first setting superview")
+            return
+        }
+
+        superview.addConstraint(NSLayoutConstraint(item: self,
+                                                   attribute: .centerY,
+                                                   relatedBy: .equal,
+                                                   toItem: superview,
+                                                   attribute: .centerY,
+                                                   multiplier: 1.0,
+                                                   constant: padding))
+    }
+    
+    /**
+     A convenience method to center the view horizontally within it's 'superview'. The view must have
+     a 'superview'.
+     
+     @param padding     The padding (or offset from center) to be applied to the constraint.
+     */
+    public func alignCenterHorizontal(padding: CGFloat) {
+        
+        guard let superview = self.superview else {
+            assertionFailure("Trying to set constraints without first setting superview")
+            return
+        }
+
+        superview.addConstraint(NSLayoutConstraint(item: self,
+                                                   attribute: .centerX,
+                                                   relatedBy: .equal,
+                                                   toItem: superview,
+                                                   attribute: .centerX,
+                                                   multiplier: 1.0,
+                                                   constant: padding))
+    }
+    
+    /**
+     A convenience method to constrain the view's width.
+     
+     @param relation    The 'NSLayoutRelation' used in the constraint.
+     @param width       A 'CGFloat' constant for the width.
+     */
+    public func makeWidth(_ relation: NSLayoutRelation, _ width : CGFloat) {
+        self.addConstraint(NSLayoutConstraint(item: self,
+                                              attribute: .width,
+                                              relatedBy: relation,
+                                              toItem: nil,
+                                              attribute: .notAnAttribute,
+                                              multiplier: 1.0,
+                                              constant: width))
+    }
+    
+    /**
+     A convenience method to constrain the view's height.
+     
+     @param relation    The 'NSLayoutRelation' used in the constraint.
+     @param height       A 'CGFloat' constant for the height.
+     */
+    public func makeHeight(_ relation: NSLayoutRelation, _ height : CGFloat) {
+        self.addConstraint(NSLayoutConstraint(item: self,
+                                              attribute: .height,
+                                              relatedBy: relation,
+                                              toItem: nil,
+                                              attribute: .notAnAttribute,
+                                              multiplier: 1.0,
+                                              constant: height))
+    }
+    
+    /**
+     A convenience method to constraint the view's width relative to its superview.
+     
+     @param multiplier       A 'CGFloat' constant for the constraint multiplier.
+     */
+    public func makeWidthEqualToSuperview(multiplier: CGFloat) {
+        
+        guard let superview = self.superview else {
+            assertionFailure("Trying to set constraints without first setting superview")
+            return
+        }
+        
+        superview.addConstraint(NSLayoutConstraint(item: self,
+                                                    attribute: .width,
+                                                    relatedBy: .equal,
+                                                    toItem: superview,
+                                                    attribute: .width,
+                                                    multiplier: multiplier,
+                                                    constant: 0.0))
+    }
+    
+    
+    /**
+     A convenience method to remove all the view's constraints that exist between it and its superview
+     or its superview's other child views. It does NOT remove constraints between the view and its child views.
+     */
+    public func removeSiblingAndAncestorConstraints() {
+        for constraint in self.constraints {
+            
+            // iOS automatically creates special types of constraints, like for intrinsicContentSize,
+            // and we don'e want these. So test here for that and skip
+            if type(of: constraint) != NSLayoutConstraint.self {
+                continue
+            }
+            
+            if constraint.firstItem as? UIView == self && !isChildView(item: constraint.secondItem) {
+                self.removeConstraint(constraint)
+            }
+        }
+        if let superview = superview {
+            for constraint in superview.constraints {
+                
+                // iOS automatically creates special types of constraints, like for intrinsicContentSize,
+                // and we don'e want these. So test here for that and skip
+                if type(of: constraint) != NSLayoutConstraint.self {
+                    continue
+                }
+                
+                if constraint.firstItem as? UIView == self || constraint.secondItem as? UIView == self {
+                    superview.removeConstraint(constraint)
+                }
+            }
+        }
+    }
+    
+    func isChildView(item : AnyObject?) -> Bool {
+        
+        var isChild = false
+        
+        if let item = item {
+            if item is UIView {
+                for subView in self.subviews {
+                    if subView == item as! NSObject {
+                        isChild = true
+                        break
+                    }
+                }
+            }
+        }
+        return isChild
+    }
+    
+    /**
+     A convenience method to return a constraint on the view that matches the supplied constraint properties.
+     If multiple constraints matching those properties are found, it returns the constraint with the highest priority.
+     
+     @param attribute   The 'NSLayoutAttribute' of the constaint to be returned.
+     @param relation    The 'NSLayoutRelation' of the constraint to be returned.
+     
+     @return            The 'NSLayoutConstraint' matching the supplied constraint properties, if any.
+     */
+    open func constraint(for attribute: NSLayoutAttribute, relation: NSLayoutRelation) -> NSLayoutConstraint? {
+        
+        var theConstraints = Array<NSLayoutConstraint>()
+        
+        // iterate the view constraints and superview constraints. In most cases, we should have only one that has the 'firstItem',
+        // 'firstAttribute' and 'relation' values that we're looking for. It's possible there could be more than one with
+        // different priorities. So, we collect all of them and return the one with highest priority.
+        
+        [self, self.superview ?? nil].forEach({
+            
+            if let constraints = $0?.constraints {
+                
+                for constraint in constraints {
+                    
+                    // iOS automatically creates special types of constraints, like for intrinsicContentSize,
+                    // and we don't want these. So we make sure we have a 'NSLayoutConstraint' base class.
+                    if type(of: constraint) != NSLayoutConstraint.self {
+                        continue
+                    }
+                    
+                    if constraint.firstItem as! NSObject == self && constraint.firstAttribute == attribute && constraint.relation == relation {
+                        theConstraints.append(constraint)
+                    }
+                }
+            }
+        })
+        
+        return theConstraints.max { $0.priority < $1.priority } ?? nil
+    }
 }


### PR DESCRIPTION
1) Move classes from 'Elevate' to 'ResearchUXFactory', rename as necessary. For example: 'ElevateStepViewController' -> 'SBAGenericStepViewController'
'ElevatePageStepViewController' -> 'SBAGenericPageStepViewController'
'ElevateStepTableData' -> 'SBAGenericStepDataSource'
'ElevateChoiceTableViewCell' -> 'SBAStepChoiceTableViewCell'
'ElevateStepHeaderView' -> 'SBAStepHeaderView'
'ElevateStepNavigationView' -> 'SBAStepNavigationView'
'ElevateStepProgressView' -> 'SBAStepProgressView'

2) Move some classes from 'BridgeAppSDK' to 'ResearchUXFactory'
‘SBARoundedButton’
‘SBAShadowGradient’
‘SBAUnderlinedButton’
‘UIColor+BridgeKeyNames’

3) Add ‘SBAVisualConsentStep’ for the consent scenes, which is a ‘ORKPageStep’. It creates a ‘SBAInstructionStep’ for each consent scene from the ‘ORKConsentDocument’. Also, modify ‘SBABaseSurveyFactory’ to return the new ‘SBAVisualConsentStep’.

4) Add ‘UIFont+BridgeKeyNames’ style class for use similar to the UIColor style class being used, both of which can be overridden by the app project.

5) Move ‘UIView+LayoutExtensions’ from ‘Elevate’ to ‘ResearchUXFactory’ and document, rename and refactor.

6) Add ‘SBAFormStep’ to return our new ‘SBAGenericStepViewController class for ORKFormSteps.

7) Modify the ‘SBANavigationFormStep’ to return our new ‘SBAGenericStepViewController’ class.