### PR TITLE
IA-349

### DIFF
--- a/ResearchUXFactory/SBAFormProtocol.swift
+++ b/ResearchUXFactory/SBAFormProtocol.swift
@@ -66,7 +66,7 @@ extension ORKQuestionStep: SBAFormStepProtocol {
     
     public var formItems: [ORKFormItem]? {
         get {
-            return [ORKFormItem(identifier: self.identifier, text: nil, answerFormat: self.answerFormat)]
+            return [ORKFormItem(identifier: self.identifier, text: nil, answerFormat: self.answerFormat, optional: self.isOptional)]
         }
         set {
             self.answerFormat = newValue?.find(withIdentifier: self.identifier)?.answerFormat


### PR DESCRIPTION
Use ORKFormItem initializer with ‘optional’ param so we can pass isOptional property of the step. This was cause of SBAConsentSharingStep appearing as optional, so user was not required to make a choice in the UI.