### PR TITLE
IA-328

### DIFF
--- a/ResearchUXFactory/SBATaskViewController.swift
+++ b/ResearchUXFactory/SBATaskViewController.swift
@@ -79,6 +79,20 @@ open class SBATaskViewController: ORKTaskViewController, ORKTaskViewControllerDe
     */
     open var hasUploadedResults: Bool = false
     
+    /**
+     The status bar style to use for the view controller currently being shown. This only works with projects
+     set with view-controller-based status bar style.
+    */
+    open var statusBarStyle: UIStatusBarStyle = .default {
+        didSet {
+            setNeedsStatusBarAppearanceUpdate()
+        }
+    }
+
+    override open var preferredStatusBarStyle: UIStatusBarStyle {
+        return statusBarStyle
+    }
+
     open override var outputDirectory: URL? {
         get {
             if let superDirectory = super.outputDirectory {


### PR DESCRIPTION
Add a property to set the status bar style to use for the view controller currently being shown. This can't be done at the step view controller level because they are contained within the task view controller. The other option is to NOT use view-controller based status bar style and instead have the step VC set the style on UIApplication, which is not a good solution.