### PR TITLE
Fix mood scale survey question to work with Bridge surveys

### DIFF
--- a/ResearchUXFactory/ORKStep+ResultsExtension.swift
+++ b/ResearchUXFactory/ORKStep+ResultsExtension.swift
@@ -268,12 +268,22 @@ extension ORKHealthKitCharacteristicTypeAnswerFormat: SBAQuestionResultMapping {
 extension ORKMoodScaleAnswerFormat : SBAQuestionResultMapping {
     
     public func questionResult(identifier: String, answer: Any?) -> ORKQuestionResult? {
-        
-        let result = ORKMoodScaleQuestionResult(identifier: identifier)
         if let num = answer as? NSNumber {
+            let result = ORKMoodScaleQuestionResult(identifier: identifier)
             result.scaleAnswer = num
+            return result
         }
-        return result
+        else if let selected = answer as? [AnyObject] {
+            let result = ORKChoiceQuestionResult(identifier: identifier)
+            result.choiceAnswers = selected
+            return result
+        }
+        else if answer != nil {
+            let result = ORKChoiceQuestionResult(identifier: identifier)
+            result.choiceAnswers = [answer!]
+            return result
+        }
+        return ORKMoodScaleQuestionResult(identifier: identifier)
     }
 }
 


### PR DESCRIPTION
Bridge surveys return the value choices as strings even if you explicitly set the desired type as an integer. This is part of returning the appropriate result type that can be parsed by the server.